### PR TITLE
initialize atomic (enum, int, bool) struct members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,12 @@ Plugins/*/Intermediate/*
 
 # Cache files for the editor to use
 DemoProject/DerivedDataCache/*
+5.00/DemoProject/Binaries
+5.00/DemoProject/Saved/Config/CrashReportClient
+5.00/DemoProject/Saved/Logs
+5.00/DemoProject/Saved
+5.00/DemoProject/Plugins/LootLockerServerSDK/Intermediate
+5.00/DemoProject/Plugins/LootLockerServerSDK/Binaries
+5.00/DemoProject/Intermediate
+5.00/DemoProject/Plugins/Developer
+5.00/DemoProject/Config/HoloLens

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
@@ -13,11 +13,11 @@ struct FLootLockerServerResponse
 	GENERATED_BODY()
 public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	bool success;
+	bool success = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	bool ServerCallHasError;
+	bool ServerCallHasError = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	int ServerCallStatusCode;
+	int ServerCallStatusCode = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	FString FullTextFromServer;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
@@ -46,7 +46,7 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	FString endpoint;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	ELootLockerServerHTTPMethod requestMethod;
+	ELootLockerServerHTTPMethod requestMethod = ELootLockerServerHTTPMethod::GET;
 };
 
 DECLARE_DELEGATE_OneParam(FServerResponseCallback, FLootLockerServerResponse);

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
@@ -63,7 +63,7 @@ struct FLootLockerServerPsn {
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString entitlement_id;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 service_label;
+	int32 service_label = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -99,13 +99,13 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerRentalOption {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 id;
+	int32 id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString name;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 duration;
+	int32 duration = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 price;
+	int32 price = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString sales_price;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -135,7 +135,7 @@ struct FLootLockerServerAssetCandidate
 {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int created_by_player_id;
+	int created_by_player_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString created_by_player_uid;
 };
@@ -145,7 +145,7 @@ struct FLootLockerServerVariation
 {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 id;
+	int32 id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString name;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -163,15 +163,15 @@ struct FLootLockerServerAsset
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int32 id;
+    int32 id = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString name;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool active;
+    bool active = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool purchasable;
+	bool purchasable = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 price;
+	int32 price = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString sales_price;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -181,13 +181,13 @@ struct FLootLockerServerAsset
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString unlocks_context;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool detachable;
+	bool detachable = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString updated;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString marked_new;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 default_variation_id;
+	int32 default_variation_id = 0;
 	//TODO: implement default loadouts
 	// UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	// FLootLockerServerDefaultLoadouts default_loadouts;
@@ -200,11 +200,11 @@ struct FLootLockerServerAsset
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FLootLockerServerRarity rarity;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool popular;
+	bool popular = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 popularity_score;
+	int32 popularity_score = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool unique_instance;
+	bool unique_instance = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FLootLockerServerExternalIdentifiers external_identifiers;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -220,11 +220,11 @@ struct FLootLockerServerAsset
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerVariation> variations;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool featured;
+	bool featured = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool context_locked;
+	bool context_locked = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool initially_purchasable;
+	bool initially_purchasable = false;
 };
 
 USTRUCT(BlueprintType)
@@ -235,7 +235,7 @@ struct FLootLockerServerGetAssetsToGameResponse : public FLootLockerServerRespon
 	TArray<FLootLockerServerAsset> items;
 	
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int32 total;
+    int32 total = 0;
 };
 
 DECLARE_DYNAMIC_DELEGATE_OneParam(FServerAssetsResponseDelegateBP, FLootLockerServerGetAssetsToGameResponse, AssetsResponse);

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAuthRequest.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAuthRequest.h
@@ -18,7 +18,7 @@ struct FLootLockerServerAuthenticationRequest
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Startup Item")
 	FString game_version;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Startup Item")
-	bool development_mode;
+	bool is_development = false;
 };
 
 USTRUCT(BlueprintType)

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCharacterRequest.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCharacterRequest.h
@@ -16,9 +16,9 @@ struct FLootLockerServerCharacter
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int id;
+	int id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool default;
+	bool default = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString name;
 };
@@ -27,9 +27,9 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerCharacterInventory {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 instance_id;
+	int32 instance_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 variation_id;
+	int32 variation_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString rental_option_id;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -47,7 +47,7 @@ struct FLootLockerServerCharacterInventoryResponse : public FLootLockerServerRes
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerCharacterInventory> items;
 };

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerHeroesRequest.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerHeroesRequest.h
@@ -17,13 +17,13 @@ struct FLootLockerServerHero
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int id;
+	int id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int hero_id;
+	int hero_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int instance_id;
+	int instance_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_default;
+	bool is_default = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString hero_name;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -38,9 +38,9 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerHeroInventory {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 instance_id;
+	int32 instance_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 variation_id;
+	int32 variation_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString rental_option_id;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -58,7 +58,7 @@ struct FLootLockerServerHeroInventoryResponse : public FLootLockerServerResponse
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerHeroInventory> items;
 };

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
@@ -30,7 +30,7 @@ struct FLootLockerServerCreateLeaderboardResponse : public FLootLockerServerResp
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int id;
+    int id = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString name;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -40,9 +40,9 @@ struct FLootLockerServerCreateLeaderboardResponse : public FLootLockerServerResp
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 USTRUCT(BlueprintType)
@@ -50,7 +50,7 @@ struct FLootLockerServerUpdateLeaderboardResponse : public FLootLockerServerResp
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int id;
+    int id = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString name;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -60,9 +60,9 @@ struct FLootLockerServerUpdateLeaderboardResponse : public FLootLockerServerResp
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 USTRUCT(BlueprintType)
@@ -70,7 +70,7 @@ struct FLootLockerServerDeleteLeaderboardResponse : public FLootLockerServerResp
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int id;
+    int id = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString name;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -80,9 +80,9 @@ struct FLootLockerServerDeleteLeaderboardResponse : public FLootLockerServerResp
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 
@@ -93,9 +93,9 @@ struct FLootLockerServerSubmitScoreResponse : public FLootLockerServerResponse
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString member_id;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int rank;
+    int rank = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int score;
+    int score = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -105,7 +105,7 @@ struct FLootLockerServerSubmitScoreRequest
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString member_id;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int score;
+    int score = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -121,9 +121,9 @@ struct FLootLockerServerCreateLeaderboardRequest
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 USTRUCT(BlueprintType)
@@ -131,11 +131,11 @@ struct FLootLockerServerDeleteLeaderboardRequest
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int leaderboardId;
+    int leaderboardId = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int count;
+    int count = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int after;
+    int after = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -151,9 +151,9 @@ struct FLootLockerServerUpdateLeaderboardRequest
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerCreateLeaderboardResponseBP, FLootLockerServerCreateLeaderboardResponse, Response);

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerPlayerRequest.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerPlayerRequest.h
@@ -15,7 +15,7 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerRental {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_rental;
+	bool is_rental = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString time_left;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -28,9 +28,9 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerInventory {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 instance_id;
+	int32 instance_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 variation_id;
+	int32 variation_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString rental_option_id;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -46,7 +46,7 @@ struct FLootLockerServerInventoryResponse : public FLootLockerServerResponse {
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };
@@ -57,13 +57,13 @@ struct FLootLockerServerAddAssetData
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 asset_id;
+	int32 asset_id = 0;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 asset_variation_id;
+	int32 asset_variation_id = 0;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 asset_rental_option_id;
+	int32 asset_rental_option_id = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -72,7 +72,7 @@ struct FLootLockerServerAddAssetResponse : public FLootLockerServerResponse
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };
@@ -83,7 +83,7 @@ struct FLootLockerServerGetPlayerLoadoutResponse : public FLootLockerServerRespo
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };
@@ -94,7 +94,7 @@ struct FLootLockerServerEquipAssetForPlayerLoadoutResponse : public FLootLockerS
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };
@@ -105,7 +105,7 @@ struct FLootLockerServerUnequipAssetForPlayerLoadoutResponse : public FLootLocke
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerStorageRequest.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerStorageRequest.h
@@ -20,7 +20,7 @@ struct FLootLockerServerPlayerStorageItemData
 	FString value;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_public;
+	bool is_public = false;
 };
 
 USTRUCT(BlueprintType)
@@ -29,7 +29,7 @@ struct FLootLockerServerPlayerStorageItem
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int player_id;
+	int player_id = 0;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerPlayerStorageItemData> items;
@@ -56,10 +56,10 @@ struct FLootLockerServerKeyValueSet
 	FString value;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_public;
+	bool is_public = false;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int order;
+	int order = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -68,7 +68,7 @@ struct FLootLockerServerPlayerStorageData
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int player_id;
+	int player_id = 0;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerKeyValueSet> sets;

--- a/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerTriggerRequest.h
+++ b/5.00/DemoProject/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerTriggerRequest.h
@@ -16,11 +16,11 @@ struct FLootLockerServerLevel
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int level;
+	int level = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_prestige;
+	bool is_prestige = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int xp_threshold;
+	int xp_threshold = 0;
 	
 };
 
@@ -30,9 +30,9 @@ struct FLootLockerServerXP
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int previous;
+	int previous = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int current;
+	int current = 0;
 };
 
 USTRUCT(BlueprintType)

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
@@ -13,11 +13,11 @@ struct FLootLockerServerResponse
 	GENERATED_BODY()
 public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	bool success;
+	bool success = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	bool ServerCallHasError;
+	bool ServerCallHasError = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	int ServerCallStatusCode;
+	int ServerCallStatusCode = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	FString FullTextFromServer;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
@@ -46,7 +46,7 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
 	FString endpoint;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere)
-	ELootLockerServerHTTPMethod requestMethod;
+	ELootLockerServerHTTPMethod requestMethod = ELootLockerServerHTTPMethod::GET;
 };
 
 DECLARE_DELEGATE_OneParam(FServerResponseCallback, FLootLockerServerResponse);

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
@@ -63,7 +63,7 @@ struct FLootLockerServerPsn {
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString entitlement_id;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 service_label;
+	int32 service_label = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -99,13 +99,13 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerRentalOption {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 id;
+	int32 id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString name;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 duration;
+	int32 duration = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 price;
+	int32 price = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString sales_price;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -135,7 +135,7 @@ struct FLootLockerServerAssetCandidate
 {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int created_by_player_id;
+	int created_by_player_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString created_by_player_uid;
 };
@@ -145,7 +145,7 @@ struct FLootLockerServerVariation
 {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 id;
+	int32 id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString name;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -163,15 +163,15 @@ struct FLootLockerServerAsset
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int32 id;
+    int32 id = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString name;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool active;
+    bool active = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool purchasable;
+	bool purchasable = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 price;
+	int32 price = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString sales_price;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -181,13 +181,13 @@ struct FLootLockerServerAsset
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString unlocks_context;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool detachable;
+	bool detachable = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString updated;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString marked_new;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 default_variation_id;
+	int32 default_variation_id = 0;
 	//TODO: implement default loadouts
 	// UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	// FLootLockerServerDefaultLoadouts default_loadouts;
@@ -200,11 +200,11 @@ struct FLootLockerServerAsset
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FLootLockerServerRarity rarity;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool popular;
+	bool popular = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 popularity_score;
+	int32 popularity_score = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool unique_instance;
+	bool unique_instance = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FLootLockerServerExternalIdentifiers external_identifiers;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -220,11 +220,11 @@ struct FLootLockerServerAsset
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerVariation> variations;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool featured;
+	bool featured = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool context_locked;
+	bool context_locked = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool initially_purchasable;
+	bool initially_purchasable = false;
 };
 
 USTRUCT(BlueprintType)
@@ -235,7 +235,7 @@ struct FLootLockerServerGetAssetsToGameResponse : public FLootLockerServerRespon
 	TArray<FLootLockerServerAsset> items;
 	
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int32 total;
+    int32 total = 0;
 };
 
 DECLARE_DYNAMIC_DELEGATE_OneParam(FServerAssetsResponseDelegateBP, FLootLockerServerGetAssetsToGameResponse, AssetsResponse);

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAuthRequest.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAuthRequest.h
@@ -18,7 +18,7 @@ struct FLootLockerServerAuthenticationRequest
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Startup Item")
 	FString game_version;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Startup Item")
-	bool development_mode;
+	bool development_mode = false;
 };
 
 USTRUCT(BlueprintType)

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCharacterRequest.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCharacterRequest.h
@@ -16,9 +16,9 @@ struct FLootLockerServerCharacter
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int id;
+	int id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool default;
+	bool default = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString name;
 };
@@ -27,9 +27,9 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerCharacterInventory {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 instance_id;
+	int32 instance_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 variation_id;
+	int32 variation_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString rental_option_id;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -47,7 +47,7 @@ struct FLootLockerServerCharacterInventoryResponse : public FLootLockerServerRes
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerCharacterInventory> items;
 };

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerHeroesRequest.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerHeroesRequest.h
@@ -17,13 +17,13 @@ struct FLootLockerServerHero
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int id;
+	int id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int hero_id;
+	int hero_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int instance_id;
+	int instance_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_default;
+	bool is_default = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString hero_name;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -38,9 +38,9 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerHeroInventory {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 instance_id;
+	int32 instance_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 variation_id;
+	int32 variation_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString rental_option_id;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -58,7 +58,7 @@ struct FLootLockerServerHeroInventoryResponse : public FLootLockerServerResponse
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerHeroInventory> items;
 };

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
@@ -30,7 +30,7 @@ struct FLootLockerServerCreateLeaderboardResponse : public FLootLockerServerResp
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int id;
+    int id = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString name;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -40,9 +40,9 @@ struct FLootLockerServerCreateLeaderboardResponse : public FLootLockerServerResp
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 USTRUCT(BlueprintType)
@@ -50,7 +50,7 @@ struct FLootLockerServerUpdateLeaderboardResponse : public FLootLockerServerResp
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int id;
+    int id = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString name;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -60,9 +60,9 @@ struct FLootLockerServerUpdateLeaderboardResponse : public FLootLockerServerResp
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 USTRUCT(BlueprintType)
@@ -70,7 +70,7 @@ struct FLootLockerServerDeleteLeaderboardResponse : public FLootLockerServerResp
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int id;
+    int id = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString name;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -80,9 +80,9 @@ struct FLootLockerServerDeleteLeaderboardResponse : public FLootLockerServerResp
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 
@@ -93,9 +93,9 @@ struct FLootLockerServerSubmitScoreResponse : public FLootLockerServerResponse
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString member_id;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int rank;
+    int rank = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int score;
+    int score = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -105,7 +105,7 @@ struct FLootLockerServerSubmitScoreRequest
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString member_id;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int score;
+    int score = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -121,9 +121,9 @@ struct FLootLockerServerCreateLeaderboardRequest
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 USTRUCT(BlueprintType)
@@ -131,11 +131,11 @@ struct FLootLockerServerDeleteLeaderboardRequest
 {
     GENERATED_BODY()
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int leaderboardId;
+    int leaderboardId = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int count;
+    int count = 0;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    int after;
+    int after = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -151,9 +151,9 @@ struct FLootLockerServerUpdateLeaderboardRequest
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
     FString direction_method;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool enable_game_api_writes;
+    bool enable_game_api_writes = false;
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-    bool overwrite_score_on_submit;
+    bool overwrite_score_on_submit = false;
 };
 
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerCreateLeaderboardResponseBP, FLootLockerServerCreateLeaderboardResponse, Response);

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerPlayerRequest.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerPlayerRequest.h
@@ -15,7 +15,7 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerRental {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_rental;
+	bool is_rental = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString time_left;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -28,9 +28,9 @@ USTRUCT(BlueprintType)
 struct FLootLockerServerInventory {
 	GENERATED_BODY()
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 instance_id;
+	int32 instance_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 variation_id;
+	int32 variation_id = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	FString rental_option_id;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
@@ -46,7 +46,7 @@ struct FLootLockerServerInventoryResponse : public FLootLockerServerResponse {
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };
@@ -57,13 +57,13 @@ struct FLootLockerServerAddAssetData
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 asset_id;
+	int32 asset_id = 0;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 asset_variation_id;
+	int32 asset_variation_id = 0;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 asset_rental_option_id;
+	int32 asset_rental_option_id = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -72,7 +72,7 @@ struct FLootLockerServerAddAssetResponse : public FLootLockerServerResponse
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };
@@ -83,7 +83,7 @@ struct FLootLockerServerGetPlayerLoadoutResponse : public FLootLockerServerRespo
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };
@@ -94,7 +94,7 @@ struct FLootLockerServerEquipAssetForPlayerLoadoutResponse : public FLootLockerS
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };
@@ -105,7 +105,7 @@ struct FLootLockerServerUnequipAssetForPlayerLoadoutResponse : public FLootLocke
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int32 total;
+	int32 total = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerInventory> items;
 };

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerStorageRequest.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerStorageRequest.h
@@ -20,7 +20,7 @@ struct FLootLockerServerPlayerStorageItemData
 	FString value;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_public;
+	bool is_public = false;
 };
 
 USTRUCT(BlueprintType)
@@ -29,7 +29,7 @@ struct FLootLockerServerPlayerStorageItem
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int player_id;
+	int player_id = 0;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerPlayerStorageItemData> items;
@@ -56,10 +56,10 @@ struct FLootLockerServerKeyValueSet
 	FString value;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_public;
+	bool is_public = false;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int order;
+	int order = 0;
 };
 
 USTRUCT(BlueprintType)
@@ -68,7 +68,7 @@ struct FLootLockerServerPlayerStorageData
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int player_id;
+	int player_id = 0;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
 	TArray<FLootLockerServerKeyValueSet> sets;

--- a/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerTriggerRequest.h
+++ b/5.00/Plugins/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerTriggerRequest.h
@@ -16,11 +16,11 @@ struct FLootLockerServerLevel
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int level;
+	int level = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	bool is_prestige;
+	bool is_prestige = false;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int xp_threshold;
+	int xp_threshold = 0;
 	
 };
 
@@ -30,9 +30,9 @@ struct FLootLockerServerXP
 	GENERATED_BODY()
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int previous;
+	int previous = 0;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLocker")
-	int current;
+	int current = 0;
 };
 
 USTRUCT(BlueprintType)


### PR DESCRIPTION
Not doing so caused warnings during packaging, like this:
IntProperty FLootLockerServerDeleteLeaderboardRequest::leaderboardId is not initialized properly.