### PR TITLE
Add User-Instance-Identifier Header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ SourceArt/**/*.tga
 DemoProject/Binaries/*
 DemoProject/Plugins/*/Binaries/*
 Plugins/*/Binaries/*
+LootLockerServerSDK/Binaries/*
+LootLockerServerSDK/Intermediate/*
 
 # Builds
 Build/*

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
@@ -13,7 +13,7 @@ ULootLockerServerHttpClient* ULootLockerServerHttpClient::Instance = nullptr;
 
 ULootLockerServerHttpClient& ULootLockerServerHttpClient::GetInstance()
 {
-	if (Instance != nullptr)
+	if (Instance == nullptr)
 	{
 		Instance = NewObject<ULootLockerServerHttpClient>();
 

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
@@ -8,6 +8,7 @@
 #include "Misc/FileHelper.h"
 #include "Utils/LootLockerServerUtilities.h"
 #include "LootLockerServerLogger.h"
+#include "Misc/Guid.h"
 
 ULootLockerServerHttpClient* ULootLockerServerHttpClient::Instance = nullptr;
 
@@ -24,6 +25,7 @@ ULootLockerServerHttpClient& ULootLockerServerHttpClient::GetInstance()
 
 ULootLockerServerHttpClient::ULootLockerServerHttpClient()
 	: UserAgent(FString::Format(TEXT("X-UnrealEngineServer-Agent/{0}"), { ENGINE_VERSION_STRING }))
+	, UserInstanceIdentifier(FGuid::NewGuid().ToString())
 {
 }
 
@@ -39,7 +41,8 @@ void ULootLockerServerHttpClient::SendRequest_Internal(HTTPRequest InRequest) co
 
 	Request->SetURL(InRequest.EndPoint);
 
-	Request->SetHeader(TEXT("User-Agent"), TEXT("X-UnrealEngine-Agent"));
+	Request->SetHeader(TEXT("User-Agent"), UserAgent);
+	Request->SetHeader(TEXT("User-Instance-Identifier"), UserInstanceIdentifier);
 	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
 	Request->SetHeader(TEXT("Accepts"), TEXT("application/json"));
 
@@ -117,7 +120,8 @@ void ULootLockerServerHttpClient::UploadRawFile_Internal(const TArray<uint8>& Ra
 
 	FString Boundary = "lootlockerboundary";
 
-	Request->SetHeader(TEXT("User-Agent"), TEXT("X-UnrealEngine-Agent"));
+	Request->SetHeader(TEXT("User-Agent"), UserAgent);
+	Request->SetHeader(TEXT("User-Instance-Identifier"), UserInstanceIdentifier);
 	Request->SetHeader(TEXT("Content-Type"), TEXT("multipart/form-data; boundary=" + Boundary));
 
 	for (const TTuple<FString, FString>& CustomHeader : InRequest.CustomHeaders)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
@@ -22,6 +22,11 @@ ULootLockerServerHttpClient& ULootLockerServerHttpClient::GetInstance()
 	return *Instance;
 }
 
+ULootLockerServerHttpClient::ULootLockerServerHttpClient()
+	: UserAgent(FString::Format(TEXT("X-UnrealEngineServer-Agent/{0}"), { ENGINE_VERSION_STRING }))
+{
+}
+
 void ULootLockerServerHttpClient::SendRequest_Internal(HTTPRequest InRequest) const
 {
 	FHttpModule* HttpModule = &FHttpModule::Get();

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.h
@@ -44,6 +44,7 @@ public:
 private:
     ULootLockerServerHttpClient();
     const FString UserAgent;
+    const FString UserInstanceIdentifier;
     struct HTTPRequest
     {
         FString EndPoint = "";

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.h
@@ -42,6 +42,8 @@ public:
     }
 
 private:
+    ULootLockerServerHttpClient();
+    const FString UserAgent;
     struct HTTPRequest
     {
         FString EndPoint = "";


### PR DESCRIPTION
The purpose of this is to be able to keep track of a game instance across network switches and session changes for logging purposes.

Also adds the engine version to the User-Agent header

Also also, **importantly**, fixed an issue where the http client singleton was re-created each call.