### PR TITLE
Change links properties into a map

### DIFF
--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
@@ -53,20 +53,6 @@ struct FLootLockerServerAssetInstanceStorageKeyValueSet
  *
  */
 USTRUCT(BlueprintType)
-struct FLootLockerServerAssetRentalOptionLinks
-{
-    GENERATED_BODY()
-    /*
-     URL to storage from where you can download this rental option's thumbnail
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    FString Thumbnail = "";
-};
-
-/**
- *
- */
-USTRUCT(BlueprintType)
 struct FLootLockerServerAssetRentalOption
 {
     GENERATED_BODY()
@@ -103,7 +89,7 @@ struct FLootLockerServerAssetRentalOption
      Collection of links related to this rental option
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    FLootLockerServerAssetRentalOptionLinks Links;
+    TMap<FString, FString> Links;
 };
 
 /**
@@ -172,20 +158,6 @@ struct FLootLockerServerAssetCandidateInformation
  *
  */
 USTRUCT(BlueprintType)
-struct FLootLockerServerAssetVariationLinks
-{
-    GENERATED_BODY()
-    /*
-     URL to storage from where you can download this asset variation's thumbnail
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    FString Thumbnail = "";
-};
-
-/**
- *
- */
-USTRUCT(BlueprintType)
 struct FLootLockerServerAssetVariationProperty
 {
     GENERATED_BODY()
@@ -234,20 +206,6 @@ struct FLootLockerServerAssetHeroEquipException
  *
  */
 USTRUCT(BlueprintType)
-struct FLootLockerServerAssetLinks
-{
-    GENERATED_BODY()
-    /*
-     URL to storage from where you can download this rental option's thumbnail
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    FString Thumbnail = "";
-};
-
-/**
- *
- */
-USTRUCT(BlueprintType)
 struct FLootLockerServerAssetVariation
 {
     GENERATED_BODY()
@@ -280,7 +238,7 @@ struct FLootLockerServerAssetVariation
      Collection of links related to this asset variation
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    FLootLockerServerAssetVariationLinks Links;
+    TMap<FString, FString> Links;
 };
 
 /**
@@ -457,7 +415,7 @@ struct FLootLockerServerAssetWithoutPackageContent
      Links related to this asset
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    FLootLockerServerAssetLinks Links;
+    TMap<FString, FString> Links;
     /*
      List of key values configured for this asset
      */


### PR DESCRIPTION
https://github.com/lootlocker/sdk-issues/issues/2

**Do we want to do this????????????**

We have received "bug reports" for this feature in the past. Essentially, since the links are configured with a name, the previous implementation only works if they name their link "Thumbnail". For Unity we solved this by extending a map class and adding a property called Thumbnail that gets that item from the dictionary if it exists. So we wanted to investigate doing something similar for Unreal. This is unfortunately the best we can do. So do we want to go through with it?

### Arguments for
This will support all links that users configure

### Arguments against
This breaks backwards compatibility and is not possible to go through deprecation process
This will be slightly more cumbersome if people were only using "thumbnail" links