### PR TITLE
docs: add Copilot instructions and style guide for Unreal Server SDK

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,3 +12,10 @@ You are working in the **LootLocker Unreal Server SDK** repository.
 ## More context
 - Architecture: `.github/instructions/architecture.md`
 - Guardrails: `.github/instructions/guardrails.md`
+- Style guide: `.github/instructions/style-guide.md`
+- Patterns: `.github/instructions/patterns.md`
+- Path-specific instructions:
+	- C++ facade: `.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h.instructions.md`
+	- Blueprint facade: `.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h.instructions.md`
+	- Public ServerAPI headers: `.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/ServerAPI.instructions.md`
+	- Private ServerAPI implementations: `.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/ServerAPI.instructions.md`

--- a/.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/ServerAPI.instructions.md
+++ b/.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/ServerAPI.instructions.md
@@ -1,0 +1,40 @@
+# Path-specific instructions: Private ServerAPI implementations
+
+Applies to: `LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/**/*.cpp`
+
+## Core rule
+- Implement request execution by using `ULootLockerServerHttpClient` and existing endpoints.
+
+## Transport conventions
+- Prefer `ULootLockerServerHttpClient::SendRequest<ResponseType>(...)`.
+- Only use `SendRawRequest` / `SendRawWWWFormUrlEncodedRequest` when the payload must be handcrafted.
+
+## Endpoints and params
+- Use `ULootLockerServerEndpoints::<EndpointName>`.
+- Path params: pass ordered arguments via `TArray<FStringFormatArg>{ ... }` (do not pre-encode).
+- Query params: use `TMultiMap<FString, FString>` and only add params when meaningful (e.g., `Count > 0`).
+
+## Auth headers
+- Do not manually add `x-auth-token`.
+  - The HTTP client adds it automatically when `ULootLockerServerStateData` has a token.
+- Only add custom headers when required (e.g., `x-server-key` in session start).
+
+## Responses and errors
+- Responses should inherit `FLootLockerServerResponse` so callers consistently get:
+  - `Success`, `StatusCode`, `ErrorData`, `RequestContext`, `FullTextFromServer`
+- Do not introduce alternate error channels.
+
+## Deprecation-aware changes
+- Follow the repo deprecation flow in `.github/instructions/style-guide.md` ("Deprecation practices").
+- If an API needs to change behavior or migrate to a new backend route, prefer:
+  - keeping the old request method working (or forwarding it internally to the new endpoint)
+  - adding a new request method/type for the new behavior
+- Avoid silent breaking behavior changes in existing requests unless explicitly requested.
+
+## Logging and secrets
+- Do not log server keys, auth tokens, or other sensitive data unless obfuscating it.
+- Be mindful that HTTP logging captures request/response bodies and headers (especially when file logging is enabled).
+
+## Diff hygiene
+- Keep changes scoped to the request being implemented.
+- Avoid refactors/renames in this folder unless explicitly requested.

--- a/.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h.instructions.md
+++ b/.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h.instructions.md
@@ -1,0 +1,55 @@
+# Path-specific instructions: LootLockerServerForBlueprints facade
+
+Applies to `LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h` (and corresponding `.cpp`).
+
+## Public facade rules
+- Treat this file as the primary, customer-facing API surface. Preserve backward compatibility.
+- Prefer additive changes (new methods/overloads) over breaking changes to existing signatures, default values, namespaces, or behavior.
+- Keep diffs minimal and commit unrelated changes in separate commits/PRs.
+- Always place methods in this file in a `//==================================================\n// Leaderboards\n//==================================================` block corresponding to their feature set (for example, Authentication, Inventory, etc.) and keep them organized with related methods.
+- Docs are required for any API you add or change. Match the existing doc style in this file, including clear `param` descriptions and any practical usage notes.
+
+## Deprecation (Blueprint facade)
+- Follow the repo deprecation flow in `.github/instructions/style-guide.md` ("Deprecation practices").
+- Prefer deprecating old Blueprint-callable methods over removing/renaming them.
+- Mark deprecated Blueprint-callable methods with:
+  - `meta=(DeprecatedFunction, DeprecationMessage="Deprecated on <YYYY-MM-DD>. Use <Replacement>.")`
+- If a C++ facade method is deprecated and still exposed to Blueprints, keep the BP wrapper and mark it deprecated too to preserve parity.
+
+## Blueprint API conventions
+- Blueprint facade methods:
+  - are `UFUNCTION(BlueprintCallable, ...)`
+  - return a `FString` request id
+  - expose the return value as `UPARAM(DisplayName = "RequestId")`
+- Use the existing dynamic delegate types (suffix `ResponseBP`) and pass the typed response struct.
+
+## Required method documentation (rigorous)
+For every new or changed method, include a doc block that covers:
+- Purpose, parameter meaning + constraints, and any defaults.
+- Return value: explain request id correlation.
+- Link to Server API reference when applicable.
+- Here's a template for documentation:
+```cpp
+    /**
+    One sentence description of what this method does.
+    
+    Optional additional context or usage notes.
+    
+    @param Param1 Describe parameter purpose and constraints
+    @param OptParam1 Optional: Describe parameter purpose and constraints, and note that it is optional (e.g., "if not provided, defaults to 50")
+    @param OnCompletedRequestBP Delegate for handling the server response
+    
+    @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | <feature>", meta = (AdvancedDisplay = "OptParam1", OptParam1 = 50))
+    static UPARAM(DisplayName = "RequestId") FString ExampleMethod(int Param1, int OptParam1, const FLootLockerExampleResponseBP& OnCompletedRequestBP);
+    */
+```
+
+## Implementation expectations (wrapper only)
+- The Blueprint facade should not implement request logic.
+- It should call the C++ facade and bridge the callback using `CreateLambda` that simply executes the BP delegate:
+  - `...ResponseDelegate::CreateLambda([OnCompletedRequest](const ResponseType& Response){ OnCompletedRequest.ExecuteIfBound(Response); })`
+
+## Categories and naming
+- Use the established category format: `"LootLockerServer Methods | <Feature>"`.
+- Keep method names aligned with the C++ facade for discoverability.

--- a/.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h.instructions.md
+++ b/.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h.instructions.md
@@ -1,0 +1,54 @@
+# Path-specific instructions: LootLockerServerForCpp facade
+
+Applies to: `LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h` (and corresponding `.cpp`).
+
+## Public facade rules
+- Treat this file as the primary, customer-facing API surface. Preserve backward compatibility.
+- Prefer additive changes (new methods/overloads) over breaking changes to existing signatures, default values, namespaces, or behavior.
+- Keep diffs minimal and commit unrelated changes in separate commits/PRs.
+- Always place methods in this file in a `//==================================================\n// Leaderboards\n//==================================================` block corresponding to their feature set (for example, Authentication, Inventory, etc.) and keep them organized with related methods.
+- Docs are required for any API you add or change. Match the existing doc style in this file, including clear `param` descriptions and any practical usage notes.
+
+## Deprecation (public facade)
+- Follow the repo deprecation flow in `.github/instructions/style-guide.md` ("Deprecation practices").
+- Prefer deprecating old methods over removing/renaming them.
+- Mark deprecated C++ methods/types with `UE_DEPRECATED(<UE version>, "Deprecated on <YYYY-MM-DD>. Use <Replacement>.")`.
+- Do deprecations in their own commits and call them out explicitly.
+
+## When adding a new facade method
+- Forward logic request to existing request class in `Public/ServerAPI/` + `Private/ServerAPI/`.
+- Keep the facade implementation thin: forward call + return request id.
+
+## Required method documentation (rigorous)
+For every new or changed method, include a doc block that covers:
+- One-sentence purpose.
+- Link to the relevant Server API reference (usually `https://ref.lootlocker.com/server-api/#...`) when applicable.
+- Parameter docs including:
+  - constraints (valid ranges)
+  - pagination semantics (`count`/`after`, cursor vs index)
+  - optional behavior and defaults
+- Return value: state that the returned `FString` is a request id used to correlate callbacks.
+- Auth/session requirements when relevant (e.g., requires `StartSession` beforehand).
+- Here's a template for documentation:
+```cpp
+    /**
+    One sentence description of what this method does.
+    
+    Optional additional context or usage notes.
+    
+    @param Param1 Describe parameter purpose and constraints
+    @param OptParam1 Optional: Describe parameter purpose and constraints, and note that it is optional (e.g., "if not provided, defaults to 50")
+    @param OnCompletedRequest Delegate for handling the server response
+    
+    @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    static FString ExampleMethod(int Param1, const FLootLockerExampleResponseDelegate& OnCompletedRequest, int OptParam1 = 50);
+    */
+```
+
+## Signature and behavior conventions
+- Public facade methods are `static` and typically return a `FString` request id.
+- Use the existing delegate types (suffix `ResponseDelegate`).
+- Don’t invent new async patterns; stay consistent with existing delegates + request id.
+
+## Cross-surface consistency
+- If you add a method here that should be available to Blueprint users, ensure the Blueprint facade has the corresponding wrapper method (or explicitly document why it does not).

--- a/.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/ServerAPI.instructions.md
+++ b/.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/ServerAPI.instructions.md
@@ -1,0 +1,44 @@
+# Path-specific instructions: Public ServerAPI headers
+
+Applies to: `LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/**/*.h`
+
+## Public API + data model rules
+- Treat these headers as **public API**.
+- Keep diffs minimal; avoid drive-by reformatting.
+
+## JSON serialization compatibility (critical)
+- These structs are serialized/deserialized with `FJsonObjectConverter`.
+- Preserve backend field naming (this repo commonly uses **Snake_case** member names with a leading capital, e.g. `Instance_id`).
+- Do not rename fields (e.g., `Instance_id` → `InstanceId`) unless you also handle JSON compatibility intentionally.
+
+## Deprecation (DTOs, fields, and request/response types)
+- Follow the repo deprecation flow in `.github/instructions/style-guide.md` ("Deprecation practices").
+- Prefer additive changes to DTOs. Avoid removing or renaming existing `UPROPERTY` fields because it can break:
+  - user code (compile-time)
+  - JSON expectations (wire compatibility)
+  - Blueprint pins (graph compatibility)
+- If a field must be discouraged, keep it and mark the `UPROPERTY` with `meta=(DeprecatedProperty, DeprecationMessage="Deprecated on <YYYY-MM-DD>. Use <Replacement>.")`.
+- If a request/response type must be phased out, prefer keeping the old type and introducing a replacement type, and (where supported) mark the old C++ type as deprecated with `UE_DEPRECATED(...)`.
+
+## USTRUCT / UPROPERTY conventions
+- Use `USTRUCT(BlueprintType)` for request/response/data models that are exposed to users.
+- Use `UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")` where appropriate.
+
+## Documentation expectations
+- Document all fields of public-facing USTRUCTs, especially when:
+  - a field is optional/nullable
+  - optional / may be omitted
+  - represented as `FString` even though they are numeric/bool-like (explain how to interpret)
+  - large (e.g., base64 payloads) or sensitive
+
+## File structure
+Prefer the existing section layout:
+- Data Type Definitions
+- Request Definitions
+- Response Definitions
+- Delegate Definitions
+- API Class Definition (`UCLASS` with `static` methods)
+
+## Delegates
+- C++ delegates are `DECLARE_DELEGATE_OneParam(...)` with suffix `ResponseDelegate`.
+- Keep naming consistent and avoid introducing new delegate styles.

--- a/.github/instructions/patterns.md
+++ b/.github/instructions/patterns.md
@@ -1,0 +1,91 @@
+# Unreal Server SDK — Common implementation patterns
+
+This doc is a practical companion to the style guide. It shows the **existing** request/facade/transport patterns used in this repo.
+
+For file- and folder-specific rules (to avoid leaking instructions globally), also see the path-specific instruction files under `.github/instructions/**/*.instructions.md`.
+
+## Pattern 1: Add a new Server API request
+
+### 0) Define or reuse an endpoint
+Before adding a new request method, confirm the endpoint exists in:
+- `LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h`
+- `LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp`
+
+Conventions:
+- Search first: reuse an existing `ULootLockerServerEndpoints::<Name>` if it already matches.
+- Endpoints are initialized in the `.cpp` via `InitEndpoint("path", ELootLockerServerHTTPMethod::GET/POST/...)`.
+- Prefer adding new endpoints only when a new backend route is introduced.
+
+### 1) Add models + delegates + request entrypoint (Public)
+Create/update a header under:
+- `LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/<Feature>Request.h`
+
+Typical layout:
+- Data models: `USTRUCT(BlueprintType)` + `UPROPERTY(... Category = "LootLockerServer")`
+- Request body struct (if any)
+- Response struct inheriting `FLootLockerServerResponse`
+- C++ delegate: `DECLARE_DELEGATE_OneParam(...)`
+- `UCLASS()` request object with `static` method(s)
+
+Conventions to follow:
+- Preserve backend field naming (often `Snake_case` with a leading capital, e.g. `Instance_id`) for `FJsonObjectConverter`.
+- Document optional/nullable fields.
+
+### 2) Implement the request (Private)
+Implement in:
+- `LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/<Feature>Request.cpp`
+
+Use the centralized HTTP client:
+- `ULootLockerServerHttpClient::SendRequest<ResponseType>(RequestStructOrEmpty, Endpoint, OrderedArgs, QueryParams, OnCompletedRequest, /*optional*/ ResponseInspector, /*optional*/ CustomHeaders)`
+
+Query params:
+- Use `TMultiMap<FString, FString> QueryParams;`.
+- Only add entries when the value is meaningful (e.g. `Count > 0`).
+
+Path params:
+- Pass ordered path params as `TArray<FStringFormatArg>{ ... }`.
+- Don’t pre-encode; the HTTP client URL-encodes.
+
+## Pattern 2: Wire into the C++ facade
+
+If the new request is a common consumer need, add a facade method.
+
+Where:
+- Public declaration: `LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h`
+- Implementation: `LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp`
+
+Facade convention:
+- Keep the facade thin: forward to the request class and return the request id.
+- Add method docs (purpose, params, constraints, API doc link, return value).
+
+## Pattern 3: Wire into the Blueprint facade
+
+Blueprint users call:
+- `ULootLockerServerForBlueprints` (`Public/LootLockerServerForBlueprints.h`, `Private/LootLockerServerForBlueprints.cpp`)
+
+Convention:
+- Blueprint facade wraps the C++ facade by creating a C++ delegate via `CreateLambda` that simply calls the BP delegate:
+  - `FLootLockerServer<Op>ResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServer<Op>Response& Response) { OnCompletedRequest.ExecuteIfBound(Response); })`
+
+Blueprint method signature:
+- Returns request id: `static UPARAM(DisplayName = "RequestId") FString ...`
+- Is `UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | <Feature>")`
+
+## Pattern 4: Auth/session behavior
+
+- `StartSession` (auth request) adds `x-server-key` via `CustomHeaders` and stores the returned token via a response-inspector callback.
+- After that, `x-auth-token` is automatically added by the HTTP client when a token exists in `ULootLockerServerStateData`.
+
+Guidance:
+- Do not manually add `x-auth-token` in new requests.
+- Only requests that truly require special headers should pass `CustomHeaders`.
+
+## Pattern 5: Error handling expectations
+
+Every response type should inherit `FLootLockerServerResponse` so callers can rely on:
+- `Success` boolean
+- `StatusCode`
+- `ErrorData` (parsed when possible)
+- `RequestContext` (request id, url, method, etc.)
+
+Avoid custom error channels when you can reuse the common response shape.

--- a/.github/instructions/style-guide.md
+++ b/.github/instructions/style-guide.md
@@ -1,0 +1,187 @@
+# Unreal Server SDK — Conventions & Style Guide
+
+This guide documents **how code in this repo is structured and written** so changes stay consistent, keep diffs small, and avoid accidentally expanding the public API.
+
+Scope:
+- Runtime module only unless explicitly asked: `LootLockerServerSDK/Source/LootLockerServerSDK/`
+- **Docs-first, search-first:** reuse existing request/transport patterns.
+
+## A) Public API boundaries (server SDK)
+
+### Scoped path-specific instructions (recommended reading)
+
+This repo uses path-specific custom instructions under `.github/instructions/**/*.instructions.md` to avoid leaking rules globally.
+
+High-impact public interface files:
+- `.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h.instructions.md`
+- `.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h.instructions.md`
+
+Request layer (ServerAPI):
+- `.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/ServerAPI.instructions.md`
+- `.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/ServerAPI.instructions.md`
+
+### What is public API
+Everything under:
+- `LootLockerServerSDK/Source/LootLockerServerSDK/Public/`
+
+…is **public API**. Any change there should be treated as a compatibility and build-time decision.
+
+High-impact facade headers (widely included by consumers):
+- `.../Public/LootLockerServerForCpp.h`
+- `.../Public/LootLockerServerForBlueprints.h`
+
+### Rules for adding/changing public API
+
+1) Prefer implementation in `Private/`
+- Put request execution logic in `Private/ServerAPI/*.cpp`.
+- Put internal helpers in `Private/Utils/`.
+
+2) Be intentional when changing facade headers and avoid pulling new heavy includes into facade headers unless necessary.
+
+3) Keep public headers “stable-shaped”
+- Avoid renames or signature churn.
+- Avoid moving types between files.
+- Avoid drive-by formatting changes.
+
+4) Treat public changes as API changes
+- Any new `public` method, signature change, rename, or behavior change should be treated as an API change and should go through a deprecation period if needed.
+
+### Documentation expectations (public-facing)
+
+- **Facade methods** in `LootLockerServerForCpp.h` and `LootLockerServerForBlueprints.h` require rigorous method docs:
+  - What it does (1–2 lines)
+  - Link to API docs when available (often `https://ref.lootlocker.com/server-api/#...`)
+  - Parameters: meaning + constraints (ranges, optionality, pagination behavior)
+  - Return value: request id semantics (see below)
+  - Auth/session requirements if relevant
+
+- Request/response **data objects** (USTRUCTs used for JSON) should document fields clearly, especially when:
+  - a field is optional/nullable
+  - string-typed fields are used to represent optional numbers/bools
+  - the server uses `Snake_case` naming (leading capital) that must be preserved
+
+### Deprecation practices
+
+Go through a deprecation flow when:
+- A public method/DTO is going out of support.
+- A public method/DTO signature has been updated in a way that is not backwards compatible.
+
+How to deprecate (Unreal conventions):
+- **C++ methods/types:** use `UE_DEPRECATED(<UE version>, "Deprecated on <YYYY-MM-DD>. Use <Replacement>.")` on the declaration where possible.
+- **Blueprint-callable methods:** add `meta=(DeprecatedFunction, DeprecationMessage="Deprecated on <YYYY-MM-DD>. Use <Replacement>.")` to the `UFUNCTION`.
+- **Deprecated fields:** prefer keeping serialized fields for compatibility; if a field must be discouraged, mark the `UPROPERTY` with `meta=(DeprecatedProperty, DeprecationMessage="...")`.
+
+Process:
+- Deprecations should be done in their own commits and explicitly stated.
+- Deprecations require mention in release notes and an update of user-facing documentation.
+
+## B) Request/response conventions
+
+### Where request classes live
+- Public API (types + entrypoints): `LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/*.h`
+- Implementations: `LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/*.cpp`
+
+### Shape of a request header
+Typically the header contains, in this order:
+- `// Data Type Definitions` (USTRUCT models)
+- `// Request Definitions` (USTRUCT request bodies)
+- `// Response Definitions` (USTRUCT responses inheriting `FLootLockerServerResponse`)
+- `// Delegate Definitions` (C++ delegates)
+- `UCLASS` request object exposing `static` methods
+
+### Delegates
+
+C++ delegates (request layer):
+- `DECLARE_DELEGATE_OneParam(FLootLockerServer<Operation>ResponseDelegate, FLootLockerServer<Operation>Response);`
+
+Blueprint delegates (Blueprint facade layer):
+- `DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServer<Operation>ResponseBP, FLootLockerServer<Operation>Response, Response);`
+
+Naming:
+- Suffix `ResponseDelegate` for C++
+- Suffix `ResponseBP` for Blueprint
+
+### Return values: request id
+
+Most request functions return a `FString` **request id**.
+- The id comes from the HTTP client (`FGuid::NewGuid().ToString()`).
+- Blueprint facades expose it as `UPARAM(DisplayName = "RequestId") FString ...`.
+
+### USTRUCT / UPROPERTY rules (JSON + BP)
+
+- Use `USTRUCT(BlueprintType)` for request/response/data models that are used in responses or Blueprint-facing APIs.
+- Expose fields with `UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")` where appropriate.
+
+ServerAPI note:
+- The request/response structs in `Public/ServerAPI/` are serialized/deserialized with `FJsonObjectConverter`.
+- Preserve the existing backend field naming patterns and optional-field conventions in that folder.
+- For the strict rules, see the path-specific ServerAPI instruction files referenced above.
+
+## C) HTTP / JSON / auth conventions
+
+### Central rule: use the HTTP client
+All network calls should go through:
+- `ULootLockerServerHttpClient` (`Public/LootLockerServerHttpClient.h`, `Private/LootLockerServerHttpClient.cpp`)
+
+Use:
+- `ULootLockerServerHttpClient::SendRequest<ResponseType>(RequestStruct, Endpoint, OrderedArgs, QueryParams, OnCompletedRequest, /*optional*/ ResponseInspector, /*optional*/ CustomHeaders)`
+- `SendRawRequest` / `SendRawWWWFormUrlEncodedRequest` only when you must craft the body manually.
+
+### Endpoints
+- Endpoints are defined in `Public/LootLockerServerEndpoints.h` and initialized in `Private/LootLockerServerEndpoints.cpp`.
+- Endpoints are `FLootLockerServerEndPoint` values created via `InitEndpoint("path", ELootLockerServerHTTPMethod::GET/POST/...)`.
+
+### Path params and query params
+- Path params are passed as ordered `TArray<FStringFormatArg>` and are URL-encoded by the HTTP client.
+- Query params are passed as `TMultiMap<FString, FString>`.
+  - Follow existing pattern: only add `count`, `after`, etc. if values are non-zero / non-empty.
+
+### JSON serialization
+- Requests and responses are serialized/deserialized via `FJsonObjectConverter`.
+- The empty request body pattern is `FLootLockerServerEmptyRequest{}`.
+
+### Auth headers and token handling
+
+- `x-auth-token`
+  - Automatically added by the HTTP client when `ULootLockerServerStateData::GetServerToken()` is non-empty.
+  - Most requests should **not** manually add it.
+
+- `x-server-key`
+  - Used for `StartSession` via `CustomHeaders` from the auth request implementation.
+
+- Token storage
+  - In-memory token is stored in `ULootLockerServerStateData`.
+  - `StartSession` uses a response-inspector callback to store the token.
+
+### Error propagation
+- Responses inherit from `FLootLockerServerResponse` and always populate:
+  - `Success`, `StatusCode`, `FullTextFromServer`, `ErrorData`, `RequestContext`
+- For non-success responses, the HTTP client attempts to parse `FLootLockerServerErrorData` from the body and also reads the `retry-after` header into `Retry_after_seconds`.
+
+## D) Logging & secrets
+
+Logging utilities:
+- `FLootLockerServerLogger` (`Public/LootLockerServerLogger.h`, `Private/LootLockerServerLogger.cpp`)
+- Runtime-configurable logging lives in `ULootLockerServerConfig` (file logging + runtime log level).
+
+Do not log secrets:
+- LootLocker server key (`LootLockerServerKey`)
+- Auth token (`x-auth-token`, server session token)
+- Any PII or customer data that can appear in request/response bodies
+
+Important note:
+- The HTTP client captures request/response data and headers for logging. When adding new requests, be mindful of what you put into headers/body, especially at verbose log levels and when file logging is enabled.
+
+## E) Formatting / tooling & diff hygiene
+
+Tooling:
+- No repo-wide `.clang-format` / `.editorconfig` is currently enforced. Follow surrounding file style.
+
+Diff hygiene rules:
+- Keep changes minimal and scoped.
+- Don’t reformat unrelated code.
+- Don’t reorder large include blocks unless required.
+- Don’t touch build outputs (`Binaries/`, `Intermediate/`).
+
+Search-first:
+- Before adding a new request or data type, search for existing equivalents in `Public/ServerAPI/` and reuse patterns/types when possible.


### PR DESCRIPTION
This PR adds a docs-only, repo-scoped conventions set for the LootLocker Unreal Server SDK to keep contributions consistent and safe—especially around public API surfaces and the ServerAPI request layer.

### What changed
- Added general conventions docs:
  - [.github/instructions/style-guide.md](.github/instructions/style-guide.md)
  - [.github/instructions/patterns.md](.github/instructions/patterns.md) (includes endpoint-definition step)
- Added path-scoped Copilot instruction files (to avoid “global rule leakage” and keep stricter rules limited to the right areas):
  - C++ facade: [.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h.instructions.md](.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h.instructions.md)
  - Blueprint facade: [.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h.instructions.md](.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h.instructions.md)
  - Public DTOs/requests: [.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/ServerAPI.instructions.md](.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/ServerAPI.instructions.md)
  - Private request impls: [.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/ServerAPI.instructions.md](.github/instructions/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/ServerAPI.instructions.md)
- Updated entrypoint instructions to link everything:
  - [.github/copilot-instructions.md](.github/copilot-instructions.md)

### Key guidance captured
- Public API stability expectations (facades + DTOs): keep diffs minimal, avoid churn, preserve backward compatibility.
- ServerAPI request patterns: endpoint definitions, centralized HTTP client usage, query/path param conventions, shared response/error shape.
- JSON field naming guidance: preserve backend naming (often `Snake_case` with leading capital) for `FJsonObjectConverter`.
- Deprecation practices for methods + DTOs/fields using Unreal conventions:
  - `UE_DEPRECATED(...)`
  - `meta=(DeprecatedFunction, DeprecationMessage="...")`
  - `meta=(DeprecatedProperty, DeprecationMessage="...")`
  - plus process expectations (separate commits, release notes, and doc updates).
- Logging/secrets: avoid leaking keys/tokens/PII; be mindful HTTP logging may include headers/bodies.

This resolves https://github.com/lootlocker/index/issues/1163 for the server sdk