### PR TITLE
Quick compile verification (local + CI) for Unreal Server SDK

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,10 +8,13 @@ You are working in the **LootLocker Unreal Server SDK** repository.
 - Search before adding new code; reuse existing patterns.
 - Treat anything under `LootLockerServerSDK/Source/LootLockerServerSDK/Public/` as **public API**.
 - Prefer implementation details in `Private/`.
+- Before declaring work complete, prefer running compile verification (local script or CI workflow); see `.github/instructions/verification.md`.
+- When asked to “verify compile” locally, run `scripts/verify-compile.ps1` (don’t substitute ad-hoc build commands unless necessary).
 
 ## More context
 - Architecture: `.github/instructions/architecture.md`
 - Guardrails: `.github/instructions/guardrails.md`
+- Verification: `.github/instructions/verification.md`
 - Style guide: `.github/instructions/style-guide.md`
 - Patterns: `.github/instructions/patterns.md`
 - Path-specific instructions:

--- a/.github/instructions/guardrails.md
+++ b/.github/instructions/guardrails.md
@@ -51,8 +51,21 @@ Stop and ask a small number of clarifying questions when:
 - [ ] No changes to `.uplugin` or `*.Build.cs`
 - [ ] No changes under `Binaries/` or `Intermediate/`
 - [ ] Public API changes are intentional and justified
+- [ ] Compile verification completed (see `.github/instructions/verification.md`)
 - [ ] Only requested files changed for docs-only tasks
 
 ## Related docs
 - Architecture overview: `.github/instructions/architecture.md`
+- Verification: `.github/instructions/verification.md`
 - Copilot workspace instructions: `.github/copilot-instructions.md`
+
+## Verification guardrail (local + CI)
+
+This repo has a supported, lightweight compile verification path that should be used for routine PR validation:
+- Local (Windows): `scripts/verify-compile.ps1`
+- CI (cloud): `.github/workflows/verify-compile.yml`
+
+Rules:
+- Prefer using these verification paths before declaring a change “done”.
+- Do not commit outputs produced by verification (anything under `tmp/`).
+- Keep the lightweight verification workflow fast and single-image (matrix coverage belongs in the heavier workflows).

--- a/.github/instructions/verification.md
+++ b/.github/instructions/verification.md
@@ -1,0 +1,61 @@
+# Verification (Unreal Server SDK)
+
+This repository is an **Unreal Engine plugin**. The fastest, most deterministic compile verification is to run Unreal Automation Tool (UAT) `BuildPlugin`.
+
+This doc describes the two supported verification paths:
+- **Local (Windows):** for contributors using the repo on a workstation.
+- **CI (GitHub Actions):** for cloud verification and GH Coding Agent.
+
+## A) Local compile verification (Windows)
+
+### Prerequisites
+- Unreal Engine installed locally (e.g. UE 5.5)
+- Visual Studio / MSVC toolchain that matches your UE install
+
+### Command
+
+From repo root:
+
+```powershell
+# Run UAT BuildPlugin for Win64
+./scripts/verify-compile.ps1
+```
+
+### Configuring your local Unreal Engine path
+
+Create a repo-local, gitignored file in repo root: `unreal-dev-settings.json`
+
+```json
+{ "unreal_engine_path": "C:\\Program Files\\Epic Games\\UE_5.5" }
+```
+
+`scripts/verify-compile.ps1` reads this file automatically.
+
+### Outputs
+- Build output: `tmp/build/`
+- Log file: `tmp/logs/UAT-BuildPlugin.log`
+
+Note: `tmp/` is intentionally gitignored and should never be committed.
+
+## B) CI compile verification (GitHub Actions)
+
+The lightweight workflow runs the same check in a single Unreal Engine container image:
+- Workflow: `.github/workflows/verify-compile.yml`
+- Script invoked inside the container: `scripts/verify-compile.sh`
+
+### Default behavior
+- Uses `vars.AGENT_CHECK_UE_IMAGE`.
+- If not set, defaults to `dev-5.5`.
+- Runs `RunUAT.sh BuildPlugin` for `Linux`.
+- Uploads the UAT log as an artifact.
+
+### Manual runs
+You can override the UE image tag via the workflow dispatch input `ueImage`.
+
+## What "compile verified" means here
+
+A change is considered compile-verified when:
+- Local: `scripts/verify-compile.ps1` exits with code `0`.
+- CI: the `Verify compile (quick)` workflow job succeeds.
+
+This check is intentionally narrower than the full matrix builds (it is meant to be a fast per-commit gate). For broad version coverage, use the existing matrix workflow.

--- a/.github/workflows/verify-compile.yml
+++ b/.github/workflows/verify-compile.yml
@@ -1,0 +1,158 @@
+name: Verify compile (quick)
+run-name: "Verify compile on ${{ github.ref_name }} (${{ github.sha }})"
+
+on:
+  push:
+    branches:
+      - 'feat/**'
+      - 'fix/**'
+      - 'docs/**'
+      - 'refactor/**'
+      - 'chore/**'
+      - 'test/**'
+      - 'scout/**'
+      - 'ci/**'
+      - 'meta/**'
+      - 'copilot/**'
+  workflow_dispatch:
+    inputs:
+      ueImage:
+        description: 'Unreal Engine image tag (leave empty to use AGENT_CHECK_UE_IMAGE variable)'
+        type: string
+        default: ''
+
+jobs:
+  verify-buildplugin:
+    name: Verify SDK compiles
+    runs-on: ubuntu-22.04-4-core
+    timeout-minutes: 30
+    env:
+      UE_IMAGE: ${{ github.event.inputs.ueImage || vars.AGENT_CHECK_UE_IMAGE || 'dev-5.5' }}
+
+    steps:
+      - name: Setup git
+        run: |
+          git config --global --add safe.directory /__w/unreal-server-sdk/unreal-server-sdk
+
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+
+      - name: Pull Unreal Engine image ${{ env.UE_IMAGE }}
+        run: |
+          docker login ghcr.io -u ${{ secrets.UNREAL_DOCKER_PACKAGES_READ_USERNAME }} -p ${{ secrets.UNREAL_DOCKER_PACKAGES_READ_ACCESS_TOKEN }}
+          docker pull ghcr.io/epicgames/unreal-engine:${{ env.UE_IMAGE }}
+
+      - name: Prepare build folders
+        run: |
+          mkdir -p tmp/build tmp/logs
+
+      - name: Build Plugin (Linux, single UE version)
+        id: build
+        continue-on-error: true
+        run: |
+          chmod -R 777 tmp
+          docker run --rm \
+            -v "$(pwd):/mnt/source" \
+            -e TARGET_PLATFORM=Linux \
+            ghcr.io/epicgames/unreal-engine:${{ env.UE_IMAGE }} \
+            sh -c "sh /mnt/source/scripts/verify-compile.sh"
+
+      - name: Expose build log as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compile-check-${{ env.UE_IMAGE }}-UAT.log
+          path: tmp/logs/UAT-BuildPlugin.log
+          if-no-files-found: warn
+
+      - name: Check build result and report errors
+        if: always()
+        run: |
+          LOG="$(pwd)/tmp/logs/UAT-BuildPlugin.log"
+
+          if [ ! -f "$LOG" ]; then
+            echo "## ⚠️ No build log found" >> "$GITHUB_STEP_SUMMARY"
+            echo "The Docker step may have failed before producing output." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          if grep -q "AutomationTool exiting with ExitCode=0" "$LOG"; then
+            echo "## ✅ Compilation Succeeded" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Plugin built successfully against \`${{ env.UE_IMAGE }}\`." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Extract compiler errors for the Job Summary.
+          # Handles both compiler toolchain output formats:
+          #   MSVC  : path/to/File.cpp(line): error C####: message
+          #   Clang : path/to/file.cpp:line:col: error: message
+          ERRORS=$(grep -E "\.(cpp|h)(\([0-9]+\).*error (C|LNK)[0-9]+|:[0-9]+:[0-9]+: error:)" "$LOG" || true)
+          UAT_ERRORS=$(grep -iE "^(ERROR|FATAL|Exception):" "$LOG" | head -20 || true)
+
+          parse_error_line() {
+            local line="$1"
+            local file line_num msg code
+            if [[ "$line" =~ ^(.*)\(([0-9]+)\):\ error\ ([A-Z]+[0-9]+):\ (.+)$ ]]; then
+              file=$(echo "${BASH_REMATCH[1]}" | sed 's|/mnt/source/||g')
+              line_num="${BASH_REMATCH[2]}"
+              code="${BASH_REMATCH[3]}"
+              msg="${BASH_REMATCH[4]}"
+              echo "table|${file}|${line_num}|**${code}**: ${msg}"
+            elif [[ "$line" =~ ^(.*):([0-9]+):[0-9]+:\ error:\ (.+)$ ]]; then
+              file=$(echo "${BASH_REMATCH[1]}" | sed 's|/mnt/source/||g')
+              line_num="${BASH_REMATCH[2]}"
+              msg="${BASH_REMATCH[3]}"
+              echo "table|${file}|${line_num}|${msg}"
+            fi
+          }
+
+          {
+            echo "## ❌ Compilation Failed"
+            echo ""
+            echo "**UE image:** \`${{ env.UE_IMAGE }}\`"
+            echo ""
+
+            if [ -n "$ERRORS" ]; then
+              echo "### Compiler Errors"
+              echo ""
+              echo "| File | Line | Error |"
+              echo "| ---- | ---- | ----- |"
+              while IFS= read -r line; do
+                parsed=$(parse_error_line "$line")
+                if [ -n "$parsed" ]; then
+                  IFS='|' read -r _ file line_num msg <<< "$parsed"
+                  echo "| \`${file}\` | ${line_num} | ${msg} |"
+                fi
+              done <<< "$ERRORS"
+              echo ""
+            fi
+
+            if [ -n "$UAT_ERRORS" ]; then
+              echo "### Build Tool Errors"
+              echo ""
+              echo '```'
+              echo "$UAT_ERRORS"
+              echo '```'
+            fi
+
+            echo ""
+            echo "See the \`compile-check-${{ env.UE_IMAGE }}-UAT.log\` artifact for the full log."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Inline annotations (appear in Checks and PR diff view)
+          if [ -n "$ERRORS" ]; then
+            while IFS= read -r line; do
+              parsed=$(parse_error_line "$line")
+              if [ -n "$parsed" ]; then
+                IFS='|' read -r _ file line_num msg <<< "$parsed"
+                echo "::error file=${file},line=${line_num}::${msg}"
+              fi
+            done <<< "$ERRORS"
+          fi
+
+          grep -iE "^(ERROR|FATAL):" "$LOG" | head -5 | while IFS= read -r line; do
+            echo "::error::$line"
+          done
+
+          exit 1

--- a/.github/workflows/verify-compile.yml
+++ b/.github/workflows/verify-compile.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Pull Unreal Engine image ${{ env.UE_IMAGE }}
         run: |
-          docker login ghcr.io -u ${{ secrets.UNREAL_DOCKER_PACKAGES_READ_USERNAME }} -p ${{ secrets.UNREAL_DOCKER_PACKAGES_READ_ACCESS_TOKEN }}
+          echo "${{ secrets.UNREAL_DOCKER_PACKAGES_READ_ACCESS_TOKEN }}" | docker login ghcr.io -u "${{ secrets.UNREAL_DOCKER_PACKAGES_READ_USERNAME }}" --password-stdin
           docker pull ghcr.io/epicgames/unreal-engine:${{ env.UE_IMAGE }}
 
       - name: Prepare build folders
@@ -76,7 +76,7 @@ jobs:
             exit 1
           fi
 
-          if grep -q "AutomationTool exiting with ExitCode=0" "$LOG"; then
+          if grep -iq "AutomationTool exiting with ExitCode=0" "$LOG"; then
             echo "## ✅ Compilation Succeeded" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "Plugin built successfully against \`${{ env.UE_IMAGE }}\`." >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,9 @@ DemoProject/DerivedDataCache/*
 # CodeQL artifacts
 _codeql_*
 
+# Local compile verification output
+tmp/
+
+# Developer-local Unreal settings
+unreal-dev-settings.json
+

--- a/scripts/verify-compile.ps1
+++ b/scripts/verify-compile.ps1
@@ -1,0 +1,113 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$UnrealEnginePath,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Win64')]
+    [string]$TargetPlatform = 'Win64',
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputDir,
+
+    [Parameter(Mandatory = $false)]
+    [string]$LogDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-RepoRoot {
+    $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+    return $repoRoot.Path
+}
+
+$repoRoot = Resolve-RepoRoot
+Set-Location $repoRoot
+
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+    $OutputDir = Join-Path $repoRoot 'tmp\build'
+}
+
+if ([string]::IsNullOrWhiteSpace($LogDir)) {
+    $LogDir = Join-Path $repoRoot 'tmp\logs'
+}
+
+function Get-UnrealEnginePathFromDevSettings {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    $settingsPath = Join-Path $RepoRoot 'unreal-dev-settings.json'
+    if (-not (Test-Path $settingsPath)) {
+        return $null
+    }
+
+    try {
+        $settings = Get-Content -Raw -Path $settingsPath | ConvertFrom-Json
+    } catch {
+        throw 'Failed to parse unreal-dev-settings.json. Expected JSON like: { "unreal_engine_path": "C:\Program Files\Epic Games\UE_5.5" }'
+    }
+
+    if ($null -eq $settings -or [string]::IsNullOrWhiteSpace($settings.unreal_engine_path)) {
+        throw 'unreal-dev-settings.json is missing required field "unreal_engine_path".'
+    }
+
+    return [string]$settings.unreal_engine_path
+}
+
+if ([string]::IsNullOrWhiteSpace($UnrealEnginePath)) {
+    $UnrealEnginePath = Get-UnrealEnginePathFromDevSettings -RepoRoot $repoRoot
+}
+
+if ([string]::IsNullOrWhiteSpace($UnrealEnginePath)) {
+    $UnrealEnginePath = 'C:\Program Files\Epic Games\UE_5.5'
+}
+
+$unrealEnginePathResolved = Resolve-Path -Path $UnrealEnginePath -ErrorAction Stop
+$runUatBat = Join-Path $unrealEnginePathResolved.Path 'Engine\Build\BatchFiles\RunUAT.bat'
+
+if (-not (Test-Path $runUatBat)) {
+    throw "RunUAT.bat not found at: $runUatBat. Provide -UnrealEnginePath or create unreal-dev-settings.json."
+}
+
+$uplugin = Join-Path $repoRoot 'LootLockerServerSDK\LootLockerServerSDK.uplugin'
+if (-not (Test-Path $uplugin)) {
+    throw "Plugin descriptor not found at: $uplugin"
+}
+
+if (Test-Path $OutputDir) {
+    try {
+        Remove-Item -Recurse -Force -Path $OutputDir
+    } catch {
+        throw "Failed to clean output directory: $OutputDir. Close any Unreal/VS processes that might have files locked and try again."
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+$logPath = Join-Path $LogDir 'UAT-BuildPlugin.log'
+if (Test-Path $logPath) {
+    Remove-Item -Force $logPath
+}
+
+Write-Host "Using Unreal Engine: $($unrealEnginePathResolved.Path)"
+Write-Host "Building plugin: $uplugin"
+Write-Host "Target platform: $TargetPlatform"
+Write-Host "Output directory: $OutputDir"
+Write-Host "Log file: $logPath"
+
+& $runUatBat BuildPlugin `
+    "-Plugin=$uplugin" `
+    "-Package=$OutputDir" `
+    "-TargetPlatforms=$TargetPlatform" `
+    -Rocket 2>&1 | Tee-Object -FilePath $logPath
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "BuildPlugin failed with exit code $LASTEXITCODE. See log: $logPath"
+    exit $LASTEXITCODE
+}
+
+Write-Host 'Compile verification succeeded.'

--- a/scripts/verify-compile.sh
+++ b/scripts/verify-compile.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+UE_ROOT="${UE_ROOT:-/home/ue4/UnrealEngine}"
+RUN_UAT="$UE_ROOT/Engine/Build/BatchFiles/RunUAT.sh"
+
+TARGET_PLATFORM="${TARGET_PLATFORM:-Linux}"
+OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/tmp/build}"
+LOG_DIR="${LOG_DIR:-$REPO_ROOT/tmp/logs}"
+LOG_PATH="$LOG_DIR/UAT-BuildPlugin.log"
+
+UPLUGIN_PATH="$REPO_ROOT/LootLockerServerSDK/LootLockerServerSDK.uplugin"
+
+if [ ! -f "$RUN_UAT" ]; then
+  echo "RunUAT.sh not found at: $RUN_UAT" >&2
+  echo "Set UE_ROOT to your Unreal Engine root (inside the container this is usually /home/ue4/UnrealEngine)." >&2
+  exit 2
+fi
+
+if [ ! -f "$UPLUGIN_PATH" ]; then
+  echo "Plugin descriptor not found at: $UPLUGIN_PATH" >&2
+  exit 2
+fi
+
+mkdir -p "$OUTPUT_DIR" "$LOG_DIR"
+rm -f "$LOG_PATH"
+
+echo "Using Unreal Engine: $UE_ROOT"
+echo "Building plugin: $UPLUGIN_PATH"
+echo "Target platform: $TARGET_PLATFORM"
+echo "Output directory: $OUTPUT_DIR"
+echo "Log file: $LOG_PATH"
+
+"$RUN_UAT" BuildPlugin \
+  "-Plugin=$UPLUGIN_PATH" \
+  "-Package=$OUTPUT_DIR" \
+  "-TargetPlatforms=$TARGET_PLATFORM" \
+  -Rocket \
+  2>&1 | tee "$LOG_PATH"
+
+# UAT prints the final ExitCode; keep this check consistent with other workflows.
+if ! grep -i -q -E 'AutomationTool exiting with ExitCode=0' "$LOG_PATH"; then
+  echo "BuildPlugin did not report success. Showing errors/warnings/exit code (if present):" >&2
+  grep -i -E 'error' "$LOG_PATH" || true
+  grep -i -E 'warning' "$LOG_PATH" || true
+  grep -i -E 'ExitCode' "$LOG_PATH" || true
+  exit 1
+fi
+
+echo "Compile verification succeeded."

--- a/scripts/verify-compile.sh
+++ b/scripts/verify-compile.sh
@@ -25,6 +25,8 @@ if [ ! -f "$UPLUGIN_PATH" ]; then
   exit 2
 fi
 
+# Clean output directory to avoid stale packaging artifacts between runs.
+rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR" "$LOG_DIR"
 rm -f "$LOG_PATH"
 


### PR DESCRIPTION
Description:

Adds a lightweight, deterministic compile verification path for this plugin using UAT BuildPlugin, intended for fast iteration on work branches and for Coding Agent validation.
Keeps the existing heavier/matrix workflows as the broader coverage option; this is the “quick gate”.
What’s included:

Local verification (Windows): runs UAT BuildPlugin via [verify-compile.ps1](vscode-file://vscode-app/c:/Users/erik/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Uses [unreal-dev-settings.json](vscode-file://vscode-app/c:/Users/erik/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (gitignored) for Unreal Engine install path configuration.
Writes logs and build output under [tmp](vscode-file://vscode-app/c:/Users/erik/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (gitignored).
CI verification (GitHub Actions): [verify-compile.yml](vscode-file://vscode-app/c:/Users/erik/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Triggers on work branches (feat/**, fix/**, etc.) + manual dispatch.
Uses ueImage input or AGENT_CHECK_UE_IMAGE (fallback dev-5.5).
Uploads UAT log artifact and surfaces compiler errors in the Job Summary + inline annotations.
Documentation + agent guardrails:
Adds [verification.md](vscode-file://vscode-app/c:/Users/erik/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as the single source of truth.
Updates repo guardrails and Copilot instructions to prefer the lightweight verifier.
How to verify:

Local: run [verify-compile.ps1](vscode-file://vscode-app/c:/Users/erik/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
CI: push to a work branch (or run workflow_dispatch with optional ueImage)
Notes:

[tmp](vscode-file://vscode-app/c:/Users/erik/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [unreal-dev-settings.json](vscode-file://vscode-app/c:/Users/erik/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) are intentionally ignored to prevent committing build artifacts/local config.