### PR TITLE
fix: replace SaveConfig() with TryUpdateDefaultConfigFile() to prevent DefaultGame.ini corruption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ _codeql_*
 
 # Local compile verification output
 tmp/
+Temp~/
 
 # Developer-local Unreal settings
 unreal-dev-settings.json

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
@@ -40,7 +40,7 @@ void ULootLockerServerConfig::EnableFileLogging(const FString& FileName)
     FString DateAppendix = FDateTime::UtcNow().ToString(TEXT("%Y-%m-%d"));
     Config->LogFilePath = FPaths::Combine(LogDir, FileName + TEXT("_") + DateAppendix + TEXT(".log"));
     Config->LongLogFilePath = FPaths::ConvertRelativePathToFull(Config->LogFilePath);
-    Config->SaveConfig();
+    Config->TryUpdateDefaultConfigFile();
 }
 
 void ULootLockerServerConfig::DisableFileLogging()
@@ -49,7 +49,7 @@ void ULootLockerServerConfig::DisableFileLogging()
     Config->bEnableFileLogging = false;
     Config->LogFilePath = TEXT("");
     Config->LongLogFilePath = "";
-    Config->SaveConfig();
+    Config->TryUpdateDefaultConfigFile();
 }
 
 bool ULootLockerServerConfig::IsFileLoggingEnabled()

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Tests/LootLockerServerConfigSaveTest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Tests/LootLockerServerConfigSaveTest.cpp
@@ -1,0 +1,149 @@
+// Copyright (c) 2021 LootLocker
+
+// Regression test for issue #1411:
+// EnableFileLogging() and DisableFileLogging() must not overwrite settings in
+// DefaultGame.ini that belong to other sections/plugins.
+//
+// Run headless from the command line (no backend connection required):
+//   UnrealEditor-Cmd.exe "YourProject.uproject" -unattended -nullrhi -nosound
+//     -ExecCmds="automation RunTests LootLockerServer.Config;quit"
+
+#include "LootLockerServerConfig.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+#include "Misc/ConfigCacheIni.h"
+
+#if ENGINE_MAJOR_VERSION > 4
+
+/**
+ * Verifies that calling EnableFileLogging / DisableFileLogging does not wipe
+ * other sections in DefaultGame.ini (regression for issue #1411).
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FLootLockerServerConfigSavePreservesOtherIniSettingsTest,
+    "LootLockerServer.Config.SaveConfigPreservesOtherIniSettings",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::SmokeFilter
+)
+
+bool FLootLockerServerConfigSavePreservesOtherIniSettingsTest::RunTest(const FString& Parameters)
+{
+    // -------------------------------------------------------------------------
+    // 1. Locate the DefaultGame.ini that ULootLockerServerConfig writes to.
+    // -------------------------------------------------------------------------
+    ULootLockerServerConfig* MutableConfig = GetMutableDefault<ULootLockerServerConfig>();
+    const FString ConfigFilename = MutableConfig->GetDefaultConfigFilename();
+
+    if (!TestFalse("DefaultGame.ini path should not be empty", ConfigFilename.IsEmpty()))
+    {
+        return false;
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. Save original file-logging state so we can restore it after the test.
+    // -------------------------------------------------------------------------
+    const bool bWasEnabled = ULootLockerServerConfig::IsFileLoggingEnabled();
+    const FString OriginalLogFileName = MutableConfig->LogFileName;
+
+    // -------------------------------------------------------------------------
+    // 3. Write a "sentinel" entry into a section that LootLocker has nothing to
+    //    do with, simulating settings from another plugin stored in the same
+    //    DefaultGame.ini.
+    //
+    //    Written directly with FFileHelper to avoid GConfig path-normalisation
+    //    issues or a missing Config/ directory in a fresh test project.
+    // -------------------------------------------------------------------------
+    const FString SentinelSection = TEXT("/Script/IssueRegression1411Server.SentinelConfig");
+    const FString SentinelKey     = TEXT("SentinelValue_1411");
+    const FString SentinelValue   = TEXT("MUST_BE_PRESERVED_ACROSS_SAVECONFIG");
+
+    // Ensure the Config directory exists.
+    IPlatformFile::GetPlatformPhysical().CreateDirectoryTree(*FPaths::GetPath(ConfigFilename));
+
+    // Read any existing content, then append the sentinel section.
+    FString InitialContent;
+    FFileHelper::LoadFileToString(InitialContent, *ConfigFilename);
+
+    if (!InitialContent.IsEmpty() && !InitialContent.EndsWith(TEXT("\n")))
+    {
+        InitialContent += TEXT("\r\n");
+    }
+    InitialContent += FString::Printf(
+        TEXT("[%s]\r\n%s=%s\r\n"), *SentinelSection, *SentinelKey, *SentinelValue);
+
+    if (!TestTrue("Setup: should be able to write sentinel to config file",
+            FFileHelper::SaveStringToFile(InitialContent, *ConfigFilename)))
+    {
+        return false;
+    }
+
+    // Reload into GConfig so in-memory and on-disk state match.
+    GConfig->LoadFile(ConfigFilename);
+
+    // Confirm the sentinel is on disk before any LootLocker operations.
+    FString DiskContentsBeforeEnable;
+    if (!TestTrue("Config file should be readable from disk",
+            FFileHelper::LoadFileToString(DiskContentsBeforeEnable, *ConfigFilename)))
+    {
+        return false;
+    }
+    TestTrue("Sentinel value should be present on disk before calling EnableFileLogging",
+        DiskContentsBeforeEnable.Contains(SentinelValue));
+
+    // -------------------------------------------------------------------------
+    // 4. EnableFileLogging — this triggered the bug before the fix.
+    // -------------------------------------------------------------------------
+    const FString TestLogFileName = TEXT("LootLockerServerTestLog_1411");
+    ULootLockerServerConfig::EnableFileLogging(TestLogFileName);
+
+    FString DiskContentsAfterEnable;
+    TestTrue("Config file should still be readable from disk after EnableFileLogging",
+        FFileHelper::LoadFileToString(DiskContentsAfterEnable, *ConfigFilename));
+
+    const bool bSentinelSurvivesEnable = DiskContentsAfterEnable.Contains(SentinelValue);
+    TestTrue(
+        "After EnableFileLogging, settings from unrelated sections must not be erased "
+        "from DefaultGame.ini.  A FAIL here indicates issue #1411 is not fixed.",
+        bSentinelSurvivesEnable);
+
+    TestTrue(
+        "After EnableFileLogging, bEnableFileLogging=True must be written to DefaultGame.ini on disk",
+        DiskContentsAfterEnable.Contains(TEXT("bEnableFileLogging=True")));
+    TestTrue(
+        "After EnableFileLogging, the log file name must be written to DefaultGame.ini on disk",
+        DiskContentsAfterEnable.Contains(TestLogFileName));
+
+    // -------------------------------------------------------------------------
+    // 5. DisableFileLogging — same checks.
+    // -------------------------------------------------------------------------
+    ULootLockerServerConfig::DisableFileLogging();
+
+    FString DiskContentsAfterDisable;
+    TestTrue("Config file should still be readable from disk after DisableFileLogging",
+        FFileHelper::LoadFileToString(DiskContentsAfterDisable, *ConfigFilename));
+
+    const bool bSentinelSurvivesDisable = DiskContentsAfterDisable.Contains(SentinelValue);
+    TestTrue(
+        "After DisableFileLogging, settings from unrelated sections must not be erased "
+        "from DefaultGame.ini.  A FAIL here indicates issue #1411 is not fixed.",
+        bSentinelSurvivesDisable);
+
+    TestTrue(
+        "After DisableFileLogging, bEnableFileLogging=False must be written to DefaultGame.ini on disk",
+        DiskContentsAfterDisable.Contains(TEXT("bEnableFileLogging=False")));
+
+    // -------------------------------------------------------------------------
+    // 6. Cleanup — remove sentinel and restore original logging config.
+    // -------------------------------------------------------------------------
+    GConfig->RemoveKey(*SentinelSection, *SentinelKey, ConfigFilename);
+    GConfig->Flush(false, ConfigFilename);
+
+    if (bWasEnabled)
+    {
+        ULootLockerServerConfig::EnableFileLogging(
+            OriginalLogFileName.IsEmpty() ? TEXT("LootLockerServerLog") : OriginalLogFileName);
+    }
+
+    return true;
+}
+
+#endif // ENGINE_MAJOR_VERSION > 4

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -1,0 +1,289 @@
+#Requires -Version 5.0
+<#
+.SYNOPSIS
+    Builds the LootLocker Unreal Server SDK plugin and runs its automation tests headlessly.
+
+.DESCRIPTION
+    1. Builds the plugin via RunUAT BuildPlugin so compiled binaries are available.
+    2. Creates a minimal VerificationProject in Temp~/VerificationProject/ with a
+       directory junction pointing to the compiled build output.
+    3. Invokes UnrealEditor-Cmd.exe with -ExecCmds to run the specified tests.
+    4. Parses the output for pass/fail and exits 0 on success, 1 on failure.
+
+.PARAMETER TestFilter
+    Automation test filter passed to "automation RunTests <filter>".
+    Defaults to "LootLockerServer.Config".
+
+.NOTES
+    Exit codes: 0 = all tests passed, 1 = one or more tests failed or setup error.
+#>
+param(
+    [string]$TestFilter = "LootLockerServer.Config"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot      = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$SettingsFile  = Join-Path $RepoRoot "unreal-dev-settings.json"
+$BuildOutput   = Join-Path $RepoRoot "tmp\build"
+$BuildLog      = Join-Path $RepoRoot "tmp\logs\UAT.log"
+$ProjectDir    = Join-Path $RepoRoot "Temp~\VerificationProject"
+$ProjectName   = "VerificationProject"
+$ProjectFile   = Join-Path $ProjectDir "$ProjectName.uproject"
+$PluginLinkDir = Join-Path $ProjectDir "Plugins\LootLockerServerSDK"
+$TestLog       = Join-Path $RepoRoot "Temp~\automation-tests.log"
+
+function Write-Step { param([string]$Msg) Write-Host $Msg }
+function Write-Ok   { param([string]$Msg) Write-Host $Msg -ForegroundColor Green }
+function Write-Fail { param([string]$Msg) Write-Host $Msg -ForegroundColor Red }
+function Write-Warn { param([string]$Msg) Write-Host $Msg -ForegroundColor Yellow }
+
+Write-Step "============================================================"
+Write-Step "  LootLocker Unreal Server SDK - Automation Tests"
+Write-Step "============================================================"
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 1. Load settings
+# ---------------------------------------------------------------------------
+if (-not (Test-Path $SettingsFile)) {
+    Write-Warn "SETUP REQUIRED: 'unreal-dev-settings.json' not found at repo root."
+    Write-Step '  { "unreal_engine_path": "C:\\Program Files\\Epic Games\\UE_5.5" }'
+    exit 1
+}
+
+$Settings   = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+$UnrealRoot = $Settings.unreal_engine_path
+
+if ([string]::IsNullOrWhiteSpace($UnrealRoot) -or -not (Test-Path $UnrealRoot)) {
+    Write-Fail "ERROR: Unreal Engine path not found: $UnrealRoot"
+    exit 1
+}
+
+$RunUAT    = Join-Path $UnrealRoot "Engine\Build\BatchFiles\RunUAT.bat"
+$EditorCmd = Join-Path $UnrealRoot "Engine\Binaries\Win64\UnrealEditor-Cmd.exe"
+
+if (-not (Test-Path $RunUAT))    { Write-Fail "ERROR: RunUAT.bat not found at: $RunUAT"; exit 1 }
+if (-not (Test-Path $EditorCmd)) { Write-Fail "ERROR: UnrealEditor-Cmd.exe not found at: $EditorCmd"; exit 1 }
+
+$PluginFile = Get-ChildItem -Path (Join-Path $RepoRoot "LootLockerServerSDK") -Filter "*.uplugin" |
+              Select-Object -First 1
+if (-not $PluginFile) {
+    Write-Fail "ERROR: No .uplugin file found under $RepoRoot\LootLockerServerSDK"
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 2. Temporarily disable UBA executor (avoids spurious distributed-build errors)
+# ---------------------------------------------------------------------------
+$UbtConfigDir    = Join-Path $env:APPDATA "Unreal Engine\UnrealBuildTool"
+$UbtConfigFile   = Join-Path $UbtConfigDir "BuildConfiguration.xml"
+$UbtConfigBackup = $UbtConfigFile + ".run-tests-backup"
+$WroteUbtConfig  = $false
+
+if (-not (Test-Path $UbtConfigDir)) { New-Item -ItemType Directory -Path $UbtConfigDir -Force | Out-Null }
+if (Test-Path $UbtConfigFile) { Copy-Item $UbtConfigFile $UbtConfigBackup -Force }
+
+$noUbaXml = @'
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+  <BuildConfiguration>
+    <bAllowUBAExecutor>false</bAllowUBAExecutor>
+  </BuildConfiguration>
+</Configuration>
+'@
+[IO.File]::WriteAllText($UbtConfigFile, $noUbaXml)
+$WroteUbtConfig = $true
+
+function Restore-UbtConfig {
+    if ($script:WroteUbtConfig) {
+        if (Test-Path $script:UbtConfigBackup) {
+            Move-Item $script:UbtConfigBackup $script:UbtConfigFile -Force
+        } else {
+            Remove-Item $script:UbtConfigFile -Force -ErrorAction SilentlyContinue
+        }
+        $script:WroteUbtConfig = $false
+    }
+}
+
+Write-Step "Note: Disabled UBA local executor (restored after tests)."
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 3. Build the plugin (ensures the latest test code is compiled into binaries)
+# ---------------------------------------------------------------------------
+Write-Step "Step 1/3 - Building plugin via RunUAT BuildPlugin ..."
+Write-Step "Plugin  : $($PluginFile.FullName)"
+Write-Step "Engine  : $UnrealRoot"
+Write-Step "Output  : $BuildOutput"
+Write-Step ""
+
+$BuildLogDir = Split-Path $BuildLog
+if (-not (Test-Path $BuildLogDir)) { New-Item -ItemType Directory -Path $BuildLogDir -Force | Out-Null }
+if (Test-Path $BuildLog) { Remove-Item $BuildLog -Force }
+
+if (Test-Path $BuildOutput) {
+    & cmd /c "rmdir /S /Q `"$BuildOutput`"" 2>&1 | Out-Null
+}
+
+$prevEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+
+$buildStream = [System.IO.StreamWriter]::new($BuildLog, $false, [System.Text.Encoding]::UTF8)
+
+$uatArgs = @(
+    "BuildPlugin"
+    "-Plugin=`"$($PluginFile.FullName)`""
+    "-Package=`"$BuildOutput`""
+    "-Rocket"
+    "-TargetPlatforms=Win64"
+    "-VS2022"
+)
+
+try {
+    & $RunUAT @uatArgs 2>&1 | ForEach-Object {
+        $line = "$_"
+        $buildStream.WriteLine($line)
+        $buildStream.Flush()
+        Write-Host $line
+    }
+} finally {
+    $buildStream.Close()
+}
+$buildExit = $LASTEXITCODE
+$ErrorActionPreference = $prevEAP
+
+if ($buildExit -ne 0) {
+    Restore-UbtConfig
+    Write-Fail "BUILD FAILED - cannot run tests without compiled binaries."
+    Write-Step "Full build log: $BuildLog"
+    exit 1
+}
+Write-Step ""
+Write-Ok "Plugin built successfully."
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 4. Set up VerificationProject pointing at the compiled plugin output
+# ---------------------------------------------------------------------------
+Write-Step "Step 2/3 - Setting up VerificationProject ..."
+
+if (-not (Test-Path $ProjectDir)) {
+    New-Item -ItemType Directory -Path $ProjectDir -Force | Out-Null
+}
+
+# Always (re)write the uproject so disabled-plugin list stays current.
+$uproject = @{
+    FileVersion       = 3
+    EngineAssociation = ""
+    Category          = ""
+    Description       = ""
+    Plugins           = @(
+        @{ Name = "LootLockerServerSDK"; Enabled = $true  }
+        # Engine plugins that fail to load without a full Marketplace installation
+        @{ Name = "Bridge";              Enabled = $false }
+        @{ Name = "MegascansPlugin";     Enabled = $false }
+        @{ Name = "Fab";                 Enabled = $false }
+    )
+} | ConvertTo-Json -Depth 5
+[IO.File]::WriteAllText($ProjectFile, $uproject)
+
+$PluginsDir = Join-Path $ProjectDir "Plugins"
+if (-not (Test-Path $PluginsDir)) {
+    New-Item -ItemType Directory -Path $PluginsDir -Force | Out-Null
+}
+
+if (Test-Path $PluginLinkDir) {
+    $linkItem      = Get-Item $PluginLinkDir -Force
+    $needsRecreate = ($linkItem.LinkType -ne "Junction") -or
+                     ($linkItem.Target -and ($linkItem.Target -ne $BuildOutput))
+    if ($needsRecreate) {
+        & cmd /c "rmdir `"$PluginLinkDir`"" 2>&1 | Out-Null
+        if (Test-Path $PluginLinkDir) { Remove-Item $PluginLinkDir -Recurse -Force }
+    }
+}
+if (-not (Test-Path $PluginLinkDir)) {
+    Write-Step "Creating plugin junction: Plugins\LootLockerServerSDK -> $BuildOutput"
+    New-Item -ItemType Junction -Path $PluginLinkDir -Target $BuildOutput | Out-Null
+}
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 5. Run automation tests via UnrealEditor-Cmd.exe
+# ---------------------------------------------------------------------------
+Write-Step "Step 3/3 - Running automation tests ..."
+Write-Step "Project  : $ProjectFile"
+Write-Step "Filter   : $TestFilter"
+Write-Step "Log      : $TestLog"
+Write-Step ""
+
+$TestLogDir = Split-Path $TestLog
+if (-not (Test-Path $TestLogDir)) { New-Item -ItemType Directory -Path $TestLogDir -Force | Out-Null }
+if (Test-Path $TestLog) { Remove-Item $TestLog -Force }
+
+$execCmd    = "automation RunTests $TestFilter;quit"
+$editorArgs = @(
+    "`"$ProjectFile`""
+    "-unattended"
+    "-nullrhi"
+    "-nosound"
+    "-NoSplash"
+    "-NoPause"
+    "-stdout"
+    "-FullStdOutLogOutput"
+    "-SkipBadPlugins"
+    "-ExecCmds=`"$execCmd`""
+)
+
+$ErrorActionPreference = 'Continue'
+$outputLines = [System.Collections.Generic.List[string]]::new()
+$testStream  = [System.IO.StreamWriter]::new($TestLog, $false, [System.Text.Encoding]::UTF8)
+
+try {
+    & $EditorCmd @editorArgs 2>&1 | ForEach-Object {
+        $line = "$_"
+        $outputLines.Add($line)
+        $testStream.WriteLine($line)
+        $testStream.Flush()
+        Write-Host $line
+    }
+} finally {
+    $testStream.Close()
+    Restore-UbtConfig
+}
+$ErrorActionPreference = $prevEAP
+
+# ---------------------------------------------------------------------------
+# 6. Parse results
+# ---------------------------------------------------------------------------
+Write-Step ""
+Write-Step "--- Test results ---"
+Write-Step ""
+
+$passedLines = $outputLines | Select-String -Pattern "Test Completed\. Result=\{?(?:Passed|Success)\}?"
+$failedLines  = $outputLines | Select-String -Pattern "Test Completed\. Result=\{?(?:Failed|Fail)\}?"
+$totalPassed = ($passedLines | Measure-Object).Count
+$totalFailed = ($failedLines | Measure-Object).Count
+
+if ($failedLines) {
+    $failedLines | ForEach-Object { Write-Host $_.Line -ForegroundColor Red }
+    Write-Step ""
+}
+
+Write-Step "----------------------------------"
+Write-Step "Passed : $totalPassed"
+Write-Step "Failed : $totalFailed"
+Write-Step ""
+
+if ($totalFailed -eq 0 -and $totalPassed -gt 0) {
+    Write-Ok "ALL TESTS PASSED"
+    exit 0
+} elseif ($totalPassed -eq 0 -and $totalFailed -eq 0) {
+    Write-Fail "NO TESTS RAN - check the log for startup errors"
+    Write-Step "Full log: $TestLog"
+    exit 1
+} else {
+    Write-Fail "TESTS FAILED"
+    Write-Step "Full log: $TestLog"
+    exit 1
+}

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -12,13 +12,13 @@
 
 .PARAMETER TestFilter
     Automation test filter passed to "automation RunTests <filter>".
-    Defaults to "LootLockerServer.Config".
+    Defaults to "LootLockerServer" which runs all LootLockerServer tests.
 
 .NOTES
     Exit codes: 0 = all tests passed, 1 = one or more tests failed or setup error.
 #>
 param(
-    [string]$TestFilter = "LootLockerServer.Config"
+    [string]$TestFilter = "LootLockerServer"
 )
 
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary

Fixes issue https://github.com/lootlocker/index/issues/1411.

`SaveConfig()` in `EnableFileLogging()` and `DisableFileLogging()` was calling `GConfig->Flush(false, DefaultGame.ini)` internally. That flush rewrites the entire `DefaultGame.ini` from GConfig's in-memory state, which can silently wipe settings that other plugins or systems had written to the same file if there is any divergence between GConfig's memory and the on-disk state.

### Fix

Replace `Config->SaveConfig()` with `Config->TryUpdateDefaultConfigFile()` in both
`EnableFileLogging()` and `DisableFileLogging()`.

`TryUpdateDefaultConfigFile()` is the UE5-recommended approach for updating a `DefaultConfig`-class's ini settings: it writes **only the diff** of changed properties for this class's section, without triggering a full-file flush that can corrupt unrelated settings.

## Changes

| File | Change |
|------|--------|
| `Private/LootLockerServerConfig.cpp` | `SaveConfig()` → `TryUpdateDefaultConfigFile()` in `EnableFileLogging` and `DisableFileLogging` |
