### PR TITLE
fix: Sanitize SDK error messages to remove LootLocker-specific wording

### DIFF
--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
@@ -1007,7 +1007,7 @@ FString ULootLockerServerForBlueprints::ParseLootLockerServerMetadataEntry(const
             MetadataTypeSwitch = ELootLockerServerMetadataParserOutputTypes::OnBase64;
             return "";
         }
-        ErrorMessage = "Could not parse value \"" + ValueToParse + "\" because it is not a valid LootLockerServer Metadata Base64 Object";
+        ErrorMessage = "Could not parse value \"" + ValueToParse + "\" because it is not a valid Metadata Base64 Object";
         return "";
     }
     default:


### PR DESCRIPTION
## Summary

Addresses https://github.com/lootlocker/index/issues/1438 (duplicate: https://github.com/lootlocker/index/issues/1392).

Customers sometimes show SDK error messages directly to end users, who are unaware of LootLocker as a middleware provider. This PR replaces LootLocker-branded strings in user-surfaced error messages with neutral, end-user-friendly wording.

## Changes

| File | Change |
|------|--------|
| `Private/LootLockerServerForBlueprints.cpp` | Remove `"LootLockerServer"` prefix from metadata Base64 parse error |