### PR TITLE
feat(leaderboards): add manual reset CRUD to server SDK

### DIFF
--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
@@ -25,6 +25,10 @@ FLootLockerServerEndPoint ULootLockerServerEndpoints::GetLeaderboardArchive = In
 FLootLockerServerEndPoint ULootLockerServerEndpoints::GetLeaderboardSchedule = InitEndpoint("leaderboards/{0}/schedule", ELootLockerServerHTTPMethod::GET);
 FLootLockerServerEndPoint ULootLockerServerEndpoints::CreateLeaderboardSchedule = InitEndpoint("leaderboards/{0}/schedule", ELootLockerServerHTTPMethod::POST);
 FLootLockerServerEndPoint ULootLockerServerEndpoints::DeleteLeaderboardSchedule = InitEndpoint("leaderboards/{0}/schedule", ELootLockerServerHTTPMethod::DELETE);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::RequestManualLeaderboardReset = InitEndpoint("leaderboards/{0}/reset", ELootLockerServerHTTPMethod::POST);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::ListManualLeaderboardResets = InitEndpoint("leaderboards/{0}/reset", ELootLockerServerHTTPMethod::GET);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::GetManualLeaderboardReset = InitEndpoint("leaderboards/{0}/reset/{1}", ELootLockerServerHTTPMethod::GET);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::CancelManualLeaderboardReset = InitEndpoint("leaderboards/{0}/reset/{1}", ELootLockerServerHTTPMethod::DELETE);
 
 // Assets
 FLootLockerServerEndPoint ULootLockerServerEndpoints::GetAssets = InitEndpoint("assets", ELootLockerServerHTTPMethod::GET);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
@@ -138,6 +138,34 @@ FString ULootLockerServerForBlueprints::DeleteLeaderboardSchedule(const FString&
     }));
 }
 
+FString ULootLockerServerForBlueprints::RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseBP& OnCompletedRequest)
+{
+    return ULootLockerServerForCpp::RequestManualLeaderboardReset(LeaderboardKey, Request, FLootLockerServerRequestManualLeaderboardResetResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerManualLeaderboardResetResponse& Response) {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
+FString ULootLockerServerForBlueprints::ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseBP& OnCompletedRequest)
+{
+    return ULootLockerServerForCpp::ListManualLeaderboardResets(LeaderboardKey, FLootLockerServerListManualLeaderboardResetsResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerListManualLeaderboardResetsResponse& Response) {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
+FString ULootLockerServerForBlueprints::GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseBP& OnCompletedRequest)
+{
+    return ULootLockerServerForCpp::GetManualLeaderboardReset(LeaderboardKey, ResetId, FLootLockerServerGetManualLeaderboardResetResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerManualLeaderboardResetResponse& Response) {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
+FString ULootLockerServerForBlueprints::CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseBP& OnCompletedRequest)
+{
+    return ULootLockerServerForCpp::CancelManualLeaderboardReset(LeaderboardKey, ResetId, FLootLockerServerCancelManualLeaderboardResetResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerResponse& Response) {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
 FString ULootLockerServerForBlueprints::ListLeaderboardArchive(const FString& LeaderboardKey, const FLootLockerServerLeaderboardArchiveResponseBP& OnCompletedRequestBP)
 {
     return ULootLockerServerForCpp::ListLeaderboardArchive(LeaderboardKey, FLootLockerServerLeaderboardArchiveResponseDelegate::CreateLambda([OnCompletedRequestBP](const FLootLockerServerLeaderboardArchiveResponse& Response) {

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -123,6 +123,26 @@ FString ULootLockerServerForCpp::DeleteLeaderboardSchedule(const FString& Leader
     return ULootLockerServerLeaderboardRequest::DeleteLeaderboardSchedule(LeaderboardKey, OnCompletedRequest);
 }
 
+FString ULootLockerServerForCpp::RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerLeaderboardRequest::RequestManualLeaderboardReset(LeaderboardKey, Request, OnCompletedRequest);
+}
+
+FString ULootLockerServerForCpp::ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerLeaderboardRequest::ListManualLeaderboardResets(LeaderboardKey, OnCompletedRequest);
+}
+
+FString ULootLockerServerForCpp::GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerLeaderboardRequest::GetManualLeaderboardReset(LeaderboardKey, ResetId, OnCompletedRequest);
+}
+
+FString ULootLockerServerForCpp::CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerLeaderboardRequest::CancelManualLeaderboardReset(LeaderboardKey, ResetId, OnCompletedRequest);
+}
+
 FString ULootLockerServerForCpp::ListLeaderboardArchive(const FString& LeaderboardKey, const FLootLockerServerLeaderboardArchiveResponseDelegate& OnCompletedRequest)
 {
     return ULootLockerServerLeaderboardArchiveRequestHandler::ListLeaderboardArchive(LeaderboardKey, OnCompletedRequest);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerLeaderboardRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerLeaderboardRequest.cpp
@@ -103,3 +103,23 @@ FString ULootLockerServerLeaderboardRequest::DeleteLeaderboardSchedule(const FSt
 {
 	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerGetLeaderboardScheduleResponse>(FLootLockerServerEmptyRequest(), ULootLockerServerEndpoints::DeleteLeaderboardSchedule, { LeaderboardKey }, {}, OnCompletedRequest);
 }
+
+FString ULootLockerServerLeaderboardRequest::RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerManualLeaderboardResetResponse>(Request, ULootLockerServerEndpoints::RequestManualLeaderboardReset, { LeaderboardKey }, {}, OnCompletedRequest);
+}
+
+FString ULootLockerServerLeaderboardRequest::ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseDelegate& OnCompletedRequest)
+{
+	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListManualLeaderboardResetsResponse>(FLootLockerServerEmptyRequest(), ULootLockerServerEndpoints::ListManualLeaderboardResets, { LeaderboardKey }, {}, OnCompletedRequest);
+}
+
+FString ULootLockerServerLeaderboardRequest::GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerManualLeaderboardResetResponse>(FLootLockerServerEmptyRequest(), ULootLockerServerEndpoints::GetManualLeaderboardReset, { LeaderboardKey, ResetId }, {}, OnCompletedRequest);
+}
+
+FString ULootLockerServerLeaderboardRequest::CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerResponse>(FLootLockerServerEmptyRequest(), ULootLockerServerEndpoints::CancelManualLeaderboardReset, { LeaderboardKey, ResetId }, {}, OnCompletedRequest);
+}

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
@@ -61,6 +61,10 @@ public:
     static FLootLockerServerEndPoint GetLeaderboardSchedule;
     static FLootLockerServerEndPoint CreateLeaderboardSchedule;
     static FLootLockerServerEndPoint DeleteLeaderboardSchedule;
+    static FLootLockerServerEndPoint RequestManualLeaderboardReset;
+    static FLootLockerServerEndPoint ListManualLeaderboardResets;
+    static FLootLockerServerEndPoint GetManualLeaderboardReset;
+    static FLootLockerServerEndPoint CancelManualLeaderboardReset;
 
     // Assets
     static FLootLockerServerEndPoint GetAssets;

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -746,7 +746,6 @@ public:
 
     /**
     * Request a manual reset of a leaderboard
-    * The leaderboard must have allow_manual_resets enabled.
     * @param LeaderboardKey The Key of the leaderboard to reset
     * @param Request Request body specifying an optional name and optional scheduled time for the reset
     * @param OnCompletedRequest Delegate for handling the server response

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -315,6 +315,22 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerGetLeaderboardScheduleRespons
  Blueprint response delegate for leaderboard schedule deletion
  */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerDeleteLeaderboardScheduleResponseBP, FLootLockerServerResponse, Response);
+/*
+ Blueprint response delegate for requesting a manual leaderboard reset
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerRequestManualLeaderboardResetResponseBP, FLootLockerServerManualLeaderboardResetResponse, Response);
+/*
+ Blueprint response delegate for listing manual leaderboard resets
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListManualLeaderboardResetsResponseBP, FLootLockerServerListManualLeaderboardResetsResponse, Response);
+/*
+ Blueprint response delegate for getting a specific manual leaderboard reset
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerGetManualLeaderboardResetResponseBP, FLootLockerServerManualLeaderboardResetResponse, Response);
+/*
+ Blueprint response delegate for cancelling a manual leaderboard reset
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerCancelManualLeaderboardResetResponseBP, FLootLockerServerResponse, Response);
 
 //==================================================
 // Metadata Response Delegates
@@ -727,6 +743,51 @@ public:
     */
     UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
     static UPARAM(DisplayName = "RequestId") FString DeleteLeaderboardSchedule(const FString& LeaderboardKey, const FLootLockerServerDeleteLeaderboardScheduleResponseBP& OnCompletedRequest);
+
+    /**
+    * Request a manual reset of a leaderboard
+    * The leaderboard must have allow_manual_resets enabled.
+    * @param LeaderboardKey The Key of the leaderboard to reset
+    * @param Request Request body specifying an optional name and optional scheduled time for the reset
+    * @param OnCompletedRequest Delegate for handling the server response
+    * 
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
+    static UPARAM(DisplayName = "RequestId") FString RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseBP& OnCompletedRequest);
+
+    /**
+    * List all manual reset requests for a leaderboard
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param OnCompletedRequest Delegate for handling the server response
+    * 
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
+    static UPARAM(DisplayName = "RequestId") FString ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseBP& OnCompletedRequest);
+
+    /**
+    * Get a specific manual reset request for a leaderboard
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param ResetId The ID of the manual reset to retrieve
+    * @param OnCompletedRequest Delegate for handling the server response
+    * 
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
+    static UPARAM(DisplayName = "RequestId") FString GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseBP& OnCompletedRequest);
+
+    /**
+    * Cancel a pending manual reset request for a leaderboard
+    * Only pending resets can be cancelled.
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param ResetId The ID of the manual reset to cancel
+    * @param OnCompletedRequest Delegate for handling the server response
+    * 
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
+    static UPARAM(DisplayName = "RequestId") FString CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseBP& OnCompletedRequest);
 
     //==================================================
     // Leaderboard Archives

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -289,7 +289,6 @@ public:
 
     /**
     * Request a manual reset of a leaderboard
-    * The leaderboard must have allow_manual_resets enabled.
     * @param LeaderboardKey The Key of the leaderboard to reset
     * @param Request Request body specifying an optional name and optional scheduled time for the reset
     * @param OnCompletedRequest Delegate for handling the server response

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -287,6 +287,43 @@ public:
     */
     static FString DeleteLeaderboardSchedule(const FString& LeaderboardKey, const FLootLockerServerDeleteLeaderboardScheduleResponseDelegate& OnCompletedRequest);
 
+    /**
+    * Request a manual reset of a leaderboard
+    * The leaderboard must have allow_manual_resets enabled.
+    * @param LeaderboardKey The Key of the leaderboard to reset
+    * @param Request Request body specifying an optional name and optional scheduled time for the reset
+    * @param OnCompletedRequest Delegate for handling the server response
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+
+    /**
+    * List all manual reset requests for a leaderboard
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param OnCompletedRequest Delegate for handling the server response
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseDelegate& OnCompletedRequest);
+
+    /**
+    * Get a specific manual reset request for a leaderboard
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param ResetId The ID of the manual reset to retrieve
+    * @param OnCompletedRequest Delegate for handling the server response
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+
+    /**
+    * Cancel a pending manual reset request for a leaderboard
+    * Only pending resets can be cancelled.
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param ResetId The ID of the manual reset to cancel
+    * @param OnCompletedRequest Delegate for handling the server response
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+
     /// @}
 
     //==================================================

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
@@ -439,11 +439,6 @@ struct FLootLockerServerLeaderboard
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Has_metadata = false;
     /**
-    Whether manual resets can be requested for this leaderboard via the server API
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    bool Allow_manual_resets = false;
-    /**
     The creation time of this leaderboard
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
@@ -556,11 +551,6 @@ public:
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Overwrite_score_on_submit = false;
-    /**
-    Allow manual resets to be requested for this leaderboard via the server API
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    bool Allow_manual_resets = false;
 };
 
 USTRUCT(BlueprintType)
@@ -686,11 +676,6 @@ struct FLootLockerServerLeaderboardBaseResponse : public FLootLockerServerRespon
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Has_metadata = false;
-    /**
-    Whether manual resets can be requested for this leaderboard via the server API
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    bool Allow_manual_resets = false;
     /**
     The creation time of this leaderboard
      */

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
@@ -439,6 +439,11 @@ struct FLootLockerServerLeaderboard
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Has_metadata = false;
     /**
+    Whether manual resets can be requested for this leaderboard via the server API
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool Allow_manual_resets = false;
+    /**
     The creation time of this leaderboard
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
@@ -551,6 +556,11 @@ public:
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Overwrite_score_on_submit = false;
+    /**
+    Allow manual resets to be requested for this leaderboard via the server API
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool Allow_manual_resets = false;
 };
 
 USTRUCT(BlueprintType)
@@ -677,6 +687,11 @@ struct FLootLockerServerLeaderboardBaseResponse : public FLootLockerServerRespon
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Has_metadata = false;
     /**
+    Whether manual resets can be requested for this leaderboard via the server API
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool Allow_manual_resets = false;
+    /**
     The creation time of this leaderboard
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
@@ -785,6 +800,141 @@ struct FLootLockerServerGetLeaderboardScheduleResponse : public FLootLockerServe
     TArray<FString> schedule;
 };
 
+USTRUCT(BlueprintType)
+/**
+ * A manual leaderboard reset request that has been submitted to the server.
+ **/
+struct FLootLockerServerManualLeaderboardReset
+{
+    GENERATED_BODY()
+    /**
+     * The unique ID of this manual reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Id = 0;
+    /**
+     * The ID of the leaderboard this reset belongs to.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Leaderboard_id = 0;
+    /**
+     * The ID of the game this reset belongs to.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Game_id = 0;
+    /**
+     * Optional human-readable name for this reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name = "";
+    /**
+     * The current processing status of this reset (pending, processing, completed, failed).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Status = "";
+    /**
+     * The UTC time at which this reset is scheduled to be processed (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Scheduled_for = "";
+    /**
+     * The UTC time at which this reset was requested (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Requested_at = "";
+    /**
+     * The UTC time at which this reset was processed (ISO 8601). Empty if not yet processed.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Processed_at = "";
+    /**
+     * Error message if the reset failed. Empty if not failed.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Error_message = "";
+};
+
+USTRUCT(BlueprintType)
+/**
+ * Request body for creating a manual leaderboard reset.
+ **/
+struct FLootLockerServerCreateManualLeaderboardResetRequest
+{
+    GENERATED_BODY()
+    /**
+     * Optional human-readable name to identify this reset.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name = "";
+    /**
+     * Optional UTC time at which to schedule this reset (ISO 8601). Defaults to immediate processing.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Scheduled_for = "";
+};
+
+USTRUCT(BlueprintType)
+struct FLootLockerServerManualLeaderboardResetResponse : public FLootLockerServerResponse
+{
+    GENERATED_BODY()
+    /**
+     * The unique ID of this manual reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Id = 0;
+    /**
+     * The ID of the leaderboard this reset belongs to.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Leaderboard_id = 0;
+    /**
+     * The ID of the game this reset belongs to.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Game_id = 0;
+    /**
+     * Optional human-readable name for this reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name = "";
+    /**
+     * The current processing status of this reset (pending, processing, completed, failed).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Status = "";
+    /**
+     * The UTC time at which this reset is scheduled to be processed (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Scheduled_for = "";
+    /**
+     * The UTC time at which this reset was requested (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Requested_at = "";
+    /**
+     * The UTC time at which this reset was processed (ISO 8601). Empty if not yet processed.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Processed_at = "";
+    /**
+     * Error message if the reset failed. Empty if not failed.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Error_message = "";
+};
+
+USTRUCT(BlueprintType)
+struct FLootLockerServerListManualLeaderboardResetsResponse : public FLootLockerServerResponse
+{
+    GENERATED_BODY()
+    /**
+     * List of manual reset requests for this leaderboard.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerManualLeaderboardReset> Items;
+};
+
 USTRUCT()
 struct FLootLockerServerListLeaderboardsResponse : public FLootLockerServerResponse
 {
@@ -851,6 +1001,22 @@ DECLARE_DELEGATE_OneParam(FLootLockerServerGetLeaderboardScheduleResponseDelegat
  C++ response delegate for leaderboard schedule deletion
  */
 DECLARE_DELEGATE_OneParam(FLootLockerServerDeleteLeaderboardScheduleResponseDelegate, FLootLockerServerResponse);
+/*
+ C++ response delegate for requesting a manual leaderboard reset
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerRequestManualLeaderboardResetResponseDelegate, FLootLockerServerManualLeaderboardResetResponse);
+/*
+ C++ response delegate for listing manual leaderboard resets
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerListManualLeaderboardResetsResponseDelegate, FLootLockerServerListManualLeaderboardResetsResponse);
+/*
+ C++ response delegate for getting a specific manual leaderboard reset
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerGetManualLeaderboardResetResponseDelegate, FLootLockerServerManualLeaderboardResetResponse);
+/*
+ C++ response delegate for cancelling a manual leaderboard reset
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerCancelManualLeaderboardResetResponseDelegate, FLootLockerServerResponse);
 
 //==================================================
 // Interface Definition
@@ -876,6 +1042,11 @@ public:
     static FString GetLeaderboardSchedule(const FString& LeaderboardKey, const FLootLockerServerGetLeaderboardScheduleResponseDelegate& OnCompletedRequest);
     static FString CreateLeaderboardSchedule(const FString& LeaderboardKey, const FString& CronExpression, const FLootLockerServerGetLeaderboardScheduleResponseDelegate& OnCompletedRequest);
     static FString DeleteLeaderboardSchedule(const FString& LeaderboardKey, const FLootLockerServerDeleteLeaderboardScheduleResponseDelegate& OnCompletedRequest);
+
+    static FString RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+    static FString ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseDelegate& OnCompletedRequest);
+    static FString GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+    static FString CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseDelegate& OnCompletedRequest);
 
 public:
     ULootLockerServerLeaderboardRequest();


### PR DESCRIPTION
## Summary

Part of [#1279](https://github.com/lootlocker/index/issues/1279) — Manual Leaderboard Resets (Phase 3: SDK support).

Exposes the full manual leaderboard reset CRUD to game server developers.

### New API surface

**4 new methods** (C++ and Blueprint):

| Method | HTTP | Endpoint |
|--------|------|----------|
| `RequestManualLeaderboardReset` | POST | `leaderboards/{key}/reset` |
| `ListManualLeaderboardResets` | GET | `leaderboards/{key}/reset` |
| `GetManualLeaderboardReset` | GET | `leaderboards/{key}/reset/{id}` |
| `CancelManualLeaderboardReset` | DELETE | `leaderboards/{key}/reset/{id}` |

**New types:**
- `FLootLockerServerManualLeaderboardReset` — data struct for list response items
- `FLootLockerServerCreateManualLeaderboardResetRequest` — request body (optional `Name`, optional `Scheduled_for`)
- `FLootLockerServerManualLeaderboardResetResponse` — flat response for single-reset operations
- `FLootLockerServerListManualLeaderboardResetsResponse` — list response with `Items` array

**Updated types:**
- `FLootLockerServerLeaderboard` — added `Allow_manual_resets`
- `FLootLockerServerLeaderboardBaseResponse` — added `Allow_manual_resets`
- `FLootLockerServerLeaderboardBaseRequest` — added `Allow_manual_resets`

All methods are available in both `ULootLockerServerForCpp` and `ULootLockerServerForBlueprints`. Delegates follow existing naming conventions (`...ResponseDelegate` for C++, `...ResponseBP` for Blueprint).