### PR TITLE
feat: Add support for listing catalog items by id

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ You are working in the **LootLocker Unreal Server SDK** repository.
 - Treat anything under `LootLockerServerSDK/Source/LootLockerServerSDK/Public/` as **public API**.
 - Prefer implementation details in `Private/`.
 - Before declaring work complete, prefer running compile verification (local script or CI workflow); see `.github/instructions/verification.md`.
-- When asked to “verify compile” locally, run `scripts/verify-compile.ps1` (don’t substitute ad-hoc build commands unless necessary).
+- When asked to "verify compile" locally, run `.github\scripts\verify-compilation.ps1 -Clean` (don't substitute ad-hoc build commands unless necessary).
 
 ## More context
 - Architecture: `.github/instructions/architecture.md`

--- a/.github/instructions/verification.md
+++ b/.github/instructions/verification.md
@@ -17,8 +17,11 @@ This doc describes the two supported verification paths:
 From repo root:
 
 ```powershell
-# Run UAT BuildPlugin for Win64
-./scripts/verify-compile.ps1
+# Run UAT BuildPlugin for Win64 (full clean build)
+.\github\scripts\verify-compilation.ps1 -Clean
+
+# Incremental build (skip clean)
+.\github\scripts\verify-compilation.ps1
 ```
 
 ### Configuring your local Unreal Engine path
@@ -29,13 +32,11 @@ Create a repo-local, gitignored file in repo root: `unreal-dev-settings.json`
 { "unreal_engine_path": "C:\\Program Files\\Epic Games\\UE_5.5" }
 ```
 
-`scripts/verify-compile.ps1` reads this file automatically.
+`.github\scripts\verify-compilation.ps1` reads this file automatically.
 
 ### Outputs
-- Build output: `tmp/build/`
-- Log file: `tmp/logs/UAT-BuildPlugin.log`
-
-Note: `tmp/` is intentionally gitignored and should never be committed.
+- Build output: `Build~\PluginBuild\`
+- Log file: `Build~\UAT.log`
 
 ## B) CI compile verification (GitHub Actions)
 

--- a/.github/scripts/verify-compilation.ps1
+++ b/.github/scripts/verify-compilation.ps1
@@ -1,0 +1,231 @@
+#Requires -Version 5.0
+<#
+.SYNOPSIS
+    Verifies that the LootLocker Unreal Server SDK plugin compiles without errors.
+
+.DESCRIPTION
+    Reads unreal-dev-settings.json from the repo root, locates the plugin's
+    .uplugin file, then runs Unreal's RunUAT BuildPlugin in batch mode to
+    check that the plugin compiles cleanly on the local machine.
+
+    See .github/instructions/verification.md for setup instructions.
+
+.PARAMETER Clean
+    Delete the previous build output and plugin Intermediate/Binaries before
+    building. Omit for a faster incremental build (UAT reuses cached artifacts).
+
+.NOTES
+    Exit codes: 0 = compilation succeeded, 1 = compilation failed or setup error.
+#>
+param(
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot   = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$SettingsFile = Join-Path $RepoRoot "unreal-dev-settings.json"
+# Use a short temp path for build output to avoid Windows MAX_PATH (260 char)
+# issues with the server SDK's long filenames (e.g. LootLockerServerLeaderboardArchiveRequestHandler.cpp).
+$BuildOutput  = Join-Path $env:TEMP "LLServerSdkBuild"
+$LogFile      = Join-Path $RepoRoot "Build~\UAT.log"
+
+function Write-Step { param([string]$Msg) Write-Host $Msg }
+function Write-Ok   { param([string]$Msg) Write-Host $Msg -ForegroundColor Green }
+function Write-Fail { param([string]$Msg) Write-Host $Msg -ForegroundColor Red }
+function Write-Warn { param([string]$Msg) Write-Host $Msg -ForegroundColor Yellow }
+
+Write-Step "==========================================="
+Write-Step "  LootLocker Unreal Server SDK - Compile Check"
+Write-Step "==========================================="
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 1. Load settings
+# ---------------------------------------------------------------------------
+if (-not (Test-Path $SettingsFile)) {
+    Write-Warn "SETUP REQUIRED: 'unreal-dev-settings.json' not found at repo root."
+    Write-Step ""
+    Write-Step "Create the file with the following content:"
+    Write-Step '  { "unreal_engine_path": "C:\\Program Files\\Epic Games\\UE_5.5" }'
+    Write-Step ""
+    Write-Step "See .github/instructions/verification.md for details."
+    exit 1
+}
+
+$Settings      = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+$UnrealRoot    = $Settings.unreal_engine_path
+
+if ([string]::IsNullOrWhiteSpace($UnrealRoot)) {
+    Write-Fail "ERROR: 'unreal_engine_path' is empty in unreal-dev-settings.json."
+    exit 1
+}
+if (-not (Test-Path $UnrealRoot)) {
+    Write-Fail "ERROR: Unreal Engine path not found: $UnrealRoot"
+    exit 1
+}
+
+$RunUAT = Join-Path $UnrealRoot "Engine\Build\BatchFiles\RunUAT.bat"
+if (-not (Test-Path $RunUAT)) {
+    Write-Fail "ERROR: RunUAT.bat not found at: $RunUAT"
+    Write-Step "       Check that 'unreal_engine_path' points to the UE install root."
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 2. Locate the plugin uplugin file
+# ---------------------------------------------------------------------------
+$PluginFile = Get-ChildItem -Path $RepoRoot -Filter "*.uplugin" -Recurse -Depth 2 |
+              Where-Object { $_.FullName -notlike "*\Build~\*" } |
+              Select-Object -First 1
+
+if (-not $PluginFile) {
+    Write-Fail "ERROR: No .uplugin file found under $RepoRoot"
+    exit 1
+}
+
+Write-Step "Plugin  : $($PluginFile.FullName)"
+Write-Step "Engine  : $UnrealRoot"
+Write-Step "Output  : $BuildOutput"
+Write-Step "Log     : $LogFile"
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 3. Prepare output directories and clear stale log
+# ---------------------------------------------------------------------------
+if ($Clean) {
+    if (Test-Path $BuildOutput) {
+        Write-Step "Cleaning previous build output..."
+        & cmd /c "rmdir /S /Q `"$BuildOutput`"" 2>&1 | Out-Null
+        if (Test-Path $BuildOutput) {
+            Write-Warn "Warning: Could not fully remove previous build output at $BuildOutput - UAT will attempt to overwrite it."
+        }
+    }
+} elseif (Test-Path $BuildOutput) {
+    Write-Step "Reusing existing build output (pass -Clean to force a full rebuild)."
+}
+$LogDir = Split-Path $LogFile
+if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
+if (Test-Path $LogFile) { Remove-Item $LogFile -Force }
+
+# Clear the plugin's Intermediate and Binaries directories before UAT runs.
+if ($Clean) {
+    foreach ($staleDir in @("Intermediate", "Binaries")) {
+        $dirPath = Join-Path (Split-Path $PluginFile.FullName) $staleDir
+        if (Test-Path $dirPath) {
+            Write-Step "Clearing plugin $staleDir directory before UAT copy..."
+            & cmd /c "rmdir /S /Q `"$dirPath`"" 2>&1 | Out-Null
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 4. Temporarily disable UBA local execution
+# ---------------------------------------------------------------------------
+$UbtConfigDir = Join-Path $env:APPDATA "Unreal Engine\UnrealBuildTool"
+$UbtConfigFile = Join-Path $UbtConfigDir "BuildConfiguration.xml"
+$UbtConfigBackup = $UbtConfigFile + ".verify-compilation-backup"
+$WroteUbtConfig = $false
+
+if (-not (Test-Path $UbtConfigDir)) { New-Item -ItemType Directory -Path $UbtConfigDir -Force | Out-Null }
+
+if (Test-Path $UbtConfigFile) {
+    Copy-Item $UbtConfigFile $UbtConfigBackup -Force
+}
+
+$noUbaXml = @'
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+  <BuildConfiguration>
+    <bAllowUBAExecutor>false</bAllowUBAExecutor>
+    <bAllowUBALocalExecutor>false</bAllowUBALocalExecutor>
+    <bAllowUBALocalExecutor>false</bAllowUBALocalExecutor>
+  </BuildConfiguration>
+</Configuration>
+'@
+[IO.File]::WriteAllText($UbtConfigFile, $noUbaXml)
+$WroteUbtConfig = $true
+
+$env:UnrealBuildTool_BuildConfiguration__bAllowUBAExecutor = "false"
+
+# Kill any lingering dotnet processes from previous crashed builds.
+Get-CimInstance Win32_Process -Filter "Name = 'dotnet.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -like "*UnrealBuildTool.dll*" } |
+    ForEach-Object {
+        Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+
+Write-Step "Note: Disabled UBA local executor to avoid UbaDetours/rc.exe crash (restored after build)."
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 5. Run RunUAT BuildPlugin
+# ---------------------------------------------------------------------------
+Write-Step "Running: RunUAT BuildPlugin (Win64, this may take a few minutes on a cold cache) ..."
+Write-Step ""
+
+$uatArgs = @(
+    "BuildPlugin"
+    "-Plugin=`"$($PluginFile.FullName)`""
+    "-Package=`"$BuildOutput`""
+    "-Rocket"
+    "-TargetPlatforms=Win64"
+    "-VS2022"
+)
+
+$prevEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+
+$uatOutput = [System.Collections.Generic.List[string]]::new()
+$logStream = [System.IO.StreamWriter]::new($LogFile, $false, [System.Text.Encoding]::UTF8)
+try {
+    & $RunUAT @uatArgs 2>&1 | ForEach-Object {
+        $line = "$_"
+        $uatOutput.Add($line)
+        $logStream.WriteLine($line)
+        $logStream.Flush()
+        Write-Host $line
+    }
+} finally {
+    $logStream.Close()
+
+    if ($WroteUbtConfig) {
+        if (Test-Path $UbtConfigBackup) {
+            Move-Item $UbtConfigBackup $UbtConfigFile -Force
+        } else {
+            Remove-Item $UbtConfigFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Remove-Item Env:\UnrealBuildTool_BuildConfiguration__bAllowUBAExecutor -ErrorAction SilentlyContinue
+}
+$script:uat_exit = $LASTEXITCODE
+
+$ErrorActionPreference = $prevEAP
+
+# ---------------------------------------------------------------------------
+# 6. Report results
+# ---------------------------------------------------------------------------
+Write-Step ""
+Write-Step "--- Compilation result ---"
+Write-Step ""
+
+$compilerErrors = $uatOutput | Select-String -Pattern "error C\d+|error LNK\d+|Error:|Deprecation:|Result: Failed" | Select-String -NotMatch "0 error\(s\)|not a preferred version"
+if ($compilerErrors) {
+    $compilerErrors | ForEach-Object { Write-Host $_.Line }
+    Write-Step ""
+}
+
+Write-Step "----------------------------------"
+Write-Step ""
+
+if ($script:uat_exit -eq 0) {
+    Write-Ok "COMPILATION SUCCEEDED"
+}
+else {
+    $failureLine = $uatOutput | Select-String -Pattern "BUILD FAILED|Failed to build|ExitCode=\d+" | Select-Object -First 1
+    $reason = if ($failureLine) { $failureLine.Line.Trim() } else { "exit code: $script:uat_exit" }
+    Write-Fail "COMPILATION FAILED ($reason)"
+    Write-Step "Full log: $LogFile"
+    exit 1
+}

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ DemoProject/DerivedDataCache/*
 _codeql_*
 
 # Local compile verification output
+Build~/
 tmp/
 Temp~/
 

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
@@ -136,6 +136,7 @@ FLootLockerServerEndPoint ULootLockerServerEndpoints::ListCurrencies = InitEndpo
 
 // Catalogs
 FLootLockerServerEndPoint ULootLockerServerEndpoints::ListCatalogItemsByKey = InitEndpoint("catalogs/inspired-ibex/v1/key/{0}/prices", ELootLockerServerHTTPMethod::GET);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::ListCatalogItemsById = InitEndpoint("catalogs/inspired-ibex/v1/catalog/items", ELootLockerServerHTTPMethod::POST);
 
 // Balances
 FLootLockerServerEndPoint ULootLockerServerEndpoints::ListBalancesInWallet = InitEndpoint("balances/wallet/{0}", ELootLockerServerHTTPMethod::GET);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
@@ -872,6 +872,13 @@ FString ULootLockerServerForBlueprints::ListCatalogItemsByKey(const FString& Cat
     }));
 }
 
+FString ULootLockerServerForBlueprints::ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseBP& OnCompletedRequestBP)
+{
+    return ULootLockerServerForCpp::ListCatalogItemsById(CatalogListingIds, IncludeMetadata, MetadataKeys, FLootLockerServerListCatalogItemsByIdResponseDelegate::CreateLambda([OnCompletedRequestBP](const FLootLockerServerListCatalogItemsByIdResponse& Response) {
+        OnCompletedRequestBP.ExecuteIfBound(Response);
+    }));
+}
+
 // Balances
 
 FString ULootLockerServerForBlueprints::ListBalancesInWallet(const FString& WalletID, const FLootLockerServerListBalancesForWalletResponseBP& OnComplete)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -652,6 +652,25 @@ FString ULootLockerServerForCpp::ListCatalogItemsByKey(const FString& CatalogKey
     return ULootLockerServerCatalogRequest::ListCatalogItemsByKey(CatalogKey, Count, After, OnCompletedRequest);
 }
 
+FString ULootLockerServerForCpp::ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnCompletedRequest)
+{
+    if (CatalogListingIds.Num() == 0)
+    {
+        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not be empty", -1);
+        OnCompletedRequest.ExecuteIfBound(ErrorResponse);
+        return {};
+    }
+
+    if (CatalogListingIds.Num() > 100)
+    {
+        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not exceed 100 items", -1);
+        OnCompletedRequest.ExecuteIfBound(ErrorResponse);
+        return {};
+    }
+
+    return ULootLockerServerCatalogRequest::ListCatalogItemsById(CatalogListingIds, IncludeMetadata, MetadataKeys, OnCompletedRequest);
+}
+
 // Balances
 
 FString ULootLockerServerForCpp::ListBalancesInWallet(const FString& WalletID, const FLootLockerServerListBalancesForWalletResponseDelegate& OnComplete)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -656,14 +656,14 @@ FString ULootLockerServerForCpp::ListCatalogItemsById(const TArray<FString>& Cat
 {
     if (CatalogListingIds.Num() == 0)
     {
-        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not be empty", -1);
+        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not be empty", LootLockerServerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT);
         OnCompletedRequest.ExecuteIfBound(ErrorResponse);
         return {};
     }
 
     if (CatalogListingIds.Num() > 100)
     {
-        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not exceed 100 items", -1);
+        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not exceed 100 items", LootLockerServerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT);
         OnCompletedRequest.ExecuteIfBound(ErrorResponse);
         return {};
     }

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
@@ -50,7 +50,7 @@ FString ULootLockerServerCatalogRequest::ListCatalogItemsById(const TArray<FStri
             OnResponseCompleted);
     }
 
-    typename ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback MetadataParser =
+    ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback MetadataParser =
         ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback::CreateLambda([OnResponseCompleted](FLootLockerServerListCatalogItemsByIdResponse& Response)
     {
         if (!Response.Success || Response.Items.Num() == 0)
@@ -83,10 +83,6 @@ FString ULootLockerServerCatalogRequest::ListCatalogItemsById(const TArray<FStri
 
             for (int j = 0; j < JsonMetadataArray.Num(); j++)
             {
-                if (j >= Entry.Metadata.Num())
-                {
-                    break;
-                }
                 TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j]->AsObject();
                 if (!JsonMetadataObject.IsValid())
                 {
@@ -112,6 +108,6 @@ FString ULootLockerServerCatalogRequest::ListCatalogItemsById(const TArray<FStri
         ULootLockerServerEndpoints::ListCatalogItemsById,
         {},
         {},
-        OnResponseCompleted,
+        FLootLockerServerListCatalogItemsByIdResponseDelegate(),
         MetadataParser);
 }

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
@@ -3,6 +3,7 @@
 #include "ServerAPI/LootLockerServerCatalogRequest.h"
 
 #include "LootLockerServerHttpClient.h"
+#include "Utils/LootLockerServerUtilities.h"
 
 ULootLockerServerCatalogRequest::ULootLockerServerCatalogRequest()
 {
@@ -26,4 +27,91 @@ FString ULootLockerServerCatalogRequest::ListCatalogItemsByKey(const FString& Ca
         { CatalogKey },
         QueryParams,
         OnResponseCompleted);
+}
+
+FString ULootLockerServerCatalogRequest::ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnResponseCompleted)
+{
+    FLootLockerServerListCatalogItemsByIdRequest Request;
+    Request.Ids = CatalogListingIds;
+
+    if (IncludeMetadata)
+    {
+        Request.Includes.Metadata.All = (MetadataKeys.Num() == 0);
+        Request.Includes.Metadata.Keys = MetadataKeys;
+    }
+
+    if (!IncludeMetadata)
+    {
+        return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListCatalogItemsByIdResponse>(
+            Request,
+            ULootLockerServerEndpoints::ListCatalogItemsById,
+            {},
+            {},
+            OnResponseCompleted);
+    }
+
+    typename ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback MetadataParser =
+        ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback::CreateLambda([OnResponseCompleted](FLootLockerServerListCatalogItemsByIdResponse& Response)
+    {
+        if (!Response.Success || Response.Items.Num() == 0)
+        {
+            OnResponseCompleted.ExecuteIfBound(Response);
+            return;
+        }
+        TSharedPtr<FJsonObject> FullJsonObject = LootLockerServerUtilities::JsonObjectFromFString(Response.FullTextFromServer);
+        if (!FullJsonObject.IsValid())
+        {
+            OnResponseCompleted.ExecuteIfBound(Response);
+            return;
+        }
+        TArray<TSharedPtr<FJsonValue>> JsonItems = FullJsonObject->GetArrayField(TEXT("items"));
+        if (JsonItems.Num() != Response.Items.Num())
+        {
+            OnResponseCompleted.ExecuteIfBound(Response);
+            return;
+        }
+
+        for (int i = 0; i < JsonItems.Num(); i++)
+        {
+            TSharedPtr<FJsonObject> JsonItemObject = JsonItems[i]->AsObject();
+            if (!JsonItemObject.IsValid())
+            {
+                continue;
+            }
+            TArray<TSharedPtr<FJsonValue>> JsonMetadataArray = JsonItemObject->GetArrayField(TEXT("metadata"));
+            FLootLockerServerListCatalogItemsByIdEntry& Entry = Response.Items[i];
+
+            for (int j = 0; j < JsonMetadataArray.Num(); j++)
+            {
+                if (j >= Entry.Metadata.Num())
+                {
+                    break;
+                }
+                TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j]->AsObject();
+                if (!JsonMetadataObject.IsValid())
+                {
+                    continue;
+                }
+                FString MetadataKey = JsonMetadataObject->GetStringField(TEXT("key"));
+                for (int k = 0; k < Entry.Metadata.Num(); k++)
+                {
+                    if (Entry.Metadata[k].Key.Equals(MetadataKey))
+                    {
+                        Entry.Metadata[k]._INTERNAL_SetJsonRepresentation(*JsonMetadataObject.Get());
+                        break;
+                    }
+                }
+            }
+        }
+
+        OnResponseCompleted.ExecuteIfBound(Response);
+    });
+
+    return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListCatalogItemsByIdResponse>(
+        Request,
+        ULootLockerServerEndpoints::ListCatalogItemsById,
+        {},
+        {},
+        OnResponseCompleted,
+        MetadataParser);
 }

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
@@ -170,6 +170,7 @@ public:
 
     // Catalogs
     static FLootLockerServerEndPoint ListCatalogItemsByKey;
+    static FLootLockerServerEndPoint ListCatalogItemsById;
 
     // Balances
     static FLootLockerServerEndPoint ListBalancesInWallet;

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -175,6 +175,11 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListCurrenciesResponseBP, FLo
  */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListCatalogPricesResponseBP, FLootLockerServerListCatalogPricesResponse, Response);
 
+/**
+ * Blueprint response delegate for listing catalog items by ID
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListCatalogItemsByIdResponseBP, FLootLockerServerListCatalogItemsByIdResponse, Response);
+
 //==================================================
 // Drop Table Response Delegates
 //==================================================
@@ -1216,7 +1221,7 @@ public:
      *
      * @param PlayerID The ID of the player for whom to equip the asset
      * @param AssetID The ID of the asset to equip to the specified player's loadout
-     * @param RentalOptionID The ID of the rental option of the specified asset to equip to the specified player's loadout
+     * @param RentalOptionID The ID of the specific rental option of the specified asset to equip to the specified player's loadout
      * @param OnCompletedRequest Delegate for handling the server response
      * 
      * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
@@ -2104,6 +2109,17 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Catalogs", meta = (AdvancedDisplay = "Count,After", Count = 0, After = ""))
     static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseBP& OnCompletedRequestBP);
+
+    /**
+     List catalog items by their catalog_listing_ids, with entity details and optionally metadata inlined directly.
+     @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     @param MetadataKeys Optional: Specific metadata keys to include. If empty, all metadata is returned.
+     @param OnCompletedRequestBP Delegate for handling the server response
+     @return A unique id for this request
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Catalogs", meta = (AdvancedDisplay = "IncludeMetadata,MetadataKeys"))
+    static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseBP& OnCompletedRequestBP);
 
     //==================================================
     // Balances

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -1493,6 +1493,16 @@ public:
      */
     static FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnCompletedRequest);
 
+    /**
+     List catalog items by their catalog_listing_ids, with entity details and optionally metadata inlined directly.
+     @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     @param MetadataKeys Optional: Specific metadata keys to include. If empty, all metadata is returned.
+     @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request
+     */
+    static FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnCompletedRequest);
+
     /// @}
 
     //==================================================

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
@@ -718,5 +718,13 @@ public:
      * @param OnResponseCompleted Delegate for handling the response
      */
     static FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnResponseCompleted);
+    /**
+     * List catalog items by their catalog_listing_ids, with entity details and optionally metadata inlined directly.
+     *
+     * @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     * @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     * @param MetadataKeys Optional: specific metadata keys to include. If empty, all metadata is returned.
+     * @param OnResponseCompleted Delegate for handling the response
+     */
     static FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnResponseCompleted);
 };

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "LootLockerServerResponse.h"
+#include "ServerAPI/LootLockerServerMetadataRequest.h"
 #include "LootLockerServerCatalogRequest.generated.h"
 
 //==================================================
@@ -498,11 +499,122 @@ struct FLootLockerServerCatalogPagination
     FString Next_cursor;
 };
 
+/**
+ * A group association with the entity detail inlined directly.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerInlinedGroupAssociation
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    ELootLockerServerCatalogEntryEntityKind Kind = ELootLockerServerCatalogEntryEntityKind::Asset;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogAssetDetails Asset_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogCurrencyDetails Currency_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogProgressionPointDetails Progression_point_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogProgressionResetDetails Progression_reset_detail;
+};
+
+/**
+ * Group detail used by the ListCatalogItemsById endpoint, with association details inlined.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerInlinedGroupDetailsWithAssociations
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Description;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerInlinedGroupAssociation> Associations;
+};
+
+/**
+ * A catalog entry with entity details inlined directly.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogItemsByIdEntry : public FLootLockerServerCatalogEntry
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogAssetDetails Asset_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogCurrencyDetails Currency_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogProgressionPointDetails Progression_point_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogProgressionResetDetails Progression_reset_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerInlinedGroupDetailsWithAssociations Group_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerMetadataEntry> Metadata;
+};
+
+/**
+ * Describes why a specific catalog_listing_id could not be resolved.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogItemsByIdError
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Reason;
+};
+
+/**
+ * Metadata include configuration for catalog items lookup.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogMetadataInclude
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool All = false;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FString> Keys;
+};
+
+/**
+ * Optional includes configuration for catalog items lookup.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogItemsIncludes
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogMetadataInclude Metadata;
+};
+
 //==================================================
 // Request Definitions
 //==================================================
 
-// N/A
+/**
+ * Request body for looking up catalog items by their catalog_listing_ids.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogItemsByIdRequest
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FString> Ids;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogItemsIncludes Includes;
+};
 
 //==================================================
 // Response Definitions
@@ -557,6 +669,19 @@ struct FLootLockerServerListCatalogPricesResponse : public FLootLockerServerResp
     FLootLockerServerCatalogPagination Pagination;
 };
 
+/**
+ * Response for the ListCatalogItemsById endpoint.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogItemsByIdResponse : public FLootLockerServerResponse
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerListCatalogItemsByIdEntry> Items;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerListCatalogItemsByIdError> Errors;
+};
+
 //==================================================
 // C++ Delegate Definitions
 //==================================================
@@ -565,6 +690,10 @@ struct FLootLockerServerListCatalogPricesResponse : public FLootLockerServerResp
  * C++ response delegate for listing catalog prices
  */
 DECLARE_DELEGATE_OneParam(FLootLockerServerListCatalogPricesResponseDelegate, FLootLockerServerListCatalogPricesResponse);
+/**
+ * C++ response delegate for listing catalog items by ID
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerListCatalogItemsByIdResponseDelegate, FLootLockerServerListCatalogItemsByIdResponse);
 
 //==================================================
 // API Class Definition
@@ -589,4 +718,5 @@ public:
      * @param OnResponseCompleted Delegate for handling the response
      */
     static FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnResponseCompleted);
+    static FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnResponseCompleted);
 };


### PR DESCRIPTION
## Tracking issue

https://github.com/lootlocker/index/issues/1526 (client side reflection of https://github.com/lootlocker/index/issues/1408)

## Description

The catalog listing endpoint is a paginated view of the entire catalog, and while it is fast I found myself sometimes wanting a convenience method for looking up a single (or a batch of) catalog listing ids with their data inlined in the object and the metadata for the item all in one go.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore

## Testing notes

Automated test added