### PR TITLE
Release Candidate v6.6.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ You are working in the **LootLocker Unreal Server SDK** repository.
 - Treat anything under `LootLockerServerSDK/Source/LootLockerServerSDK/Public/` as **public API**.
 - Prefer implementation details in `Private/`.
 - Before declaring work complete, prefer running compile verification (local script or CI workflow); see `.github/instructions/verification.md`.
-- When asked to “verify compile” locally, run `scripts/verify-compile.ps1` (don’t substitute ad-hoc build commands unless necessary).
+- When asked to "verify compile" locally, run `.github\scripts\verify-compilation.ps1 -Clean` (don't substitute ad-hoc build commands unless necessary).
 
 ## More context
 - Architecture: `.github/instructions/architecture.md`

--- a/.github/instructions/release-notes.md
+++ b/.github/instructions/release-notes.md
@@ -1,0 +1,88 @@
+# Release Notes Template
+
+Use this template when drafting a GitHub release for the Unreal Server SDK.
+
+## Title Format
+
+```
+LootLocker_UnrealServerSDK_V{MAJOR}.{MINOR}.{PATCH}
+```
+
+Examples: `LootLocker_UnrealServerSDK_V6.5.0`, `LootLocker_UnrealServerSDK_V6.3.1`
+
+---
+
+## Body Template — Major/Minor Release
+
+```markdown
+### Features
+
+• 🚀 **Feature Title** — Description of the feature. Keep it user-facing and
+actionable. Mention what problem it solves or what new capability it unlocks.
+• 🪙 **Another Feature** — Another description. Use emojis to visually group
+related features (e.g. 🔔 for notifications, 🔄 for token exchange).
+• 📚 **Documentation / Tooling** — If applicable.
+• Minor additions without their own emoji header.
+
+### Fixes
+
+• Fixed an issue where X would happen when Y.
+• Fixed a crash when Z was null.
+• Fixed compilation errors on platform/engine version.
+• Fixed SDK error messages containing LootLocker-internal wording.
+
+### Breaking Changes
+
+• Removed `DeprecatedClass` / `DeprecatedMethod` — use `NewClass` / `NewMethod` instead.
+
+### Deprecations
+
+• `OldMethod` is now deprecated and will be removed in v{NEXT_MAJOR}. Migrate to `NewMethod`.
+
+### Refactoring
+
+• Summary of internal changes that users should be aware of but don't change
+the public API surface (e.g. HTTP client rewrite, delegate restructuring).
+
+### Contributors
+
+• [@username](https://github.com/username) — Summary of their contribution.
+
+Full Changelog: [v{PREV_VERSION}...v{NEW_VERSION}](https://github.com/lootlocker/unreal-server-sdk/compare/v{PREV_VERSION}...v{NEW_VERSION})
+```
+
+---
+
+## Body Template — Patch Release
+
+```markdown
+### Bug Fixes
+
+• Fixed a crash when X is null.
+• Fixed missing API export macro on helper methods.
+• Fixed packaging/building error on engine version Y.
+
+Full Changelog: [v{PREV_VERSION}...v{NEW_VERSION}](https://github.com/lootlocker/unreal-server-sdk/compare/v{PREV_VERSION}...v{NEW_VERSION})
+```
+
+---
+
+## Writing Guidelines
+
+- **Audience:** Game server developers using LootLocker from a dedicated server
+  context in Unreal Engine. Keep descriptions user-facing — describe what
+  _they_ can do or what was fixed for _them_. Use Unreal terms: Blueprint,
+  UCLASS, UFUNCTION, UPROPERTY, UObject.
+- **Links:** Use full URLs for cross-references (blog posts, docs, compare links).
+- **Emojis:** Use to visually group features. Common ones:
+  - 🚀 Major new capability
+  - 🔔 Notifications
+  - 🪙 Currency / wallets / modifiers
+  - 📚 Documentation / reference docs
+  - 🔄 Token exchange / impersonation
+  - 👥 Player management / names / lookup
+  - 🏆 Leaderboards
+  - 📊 Progression
+  - 🔍 Filtering / search
+- **Sections:** Only include sections that have content. Don't add empty headings.
+- **Compare link:** Always include the `Full Changelog` link at the bottom.

--- a/.github/instructions/verification.md
+++ b/.github/instructions/verification.md
@@ -17,8 +17,11 @@ This doc describes the two supported verification paths:
 From repo root:
 
 ```powershell
-# Run UAT BuildPlugin for Win64
-./scripts/verify-compile.ps1
+# Run UAT BuildPlugin for Win64 (full clean build)
+.\github\scripts\verify-compilation.ps1 -Clean
+
+# Incremental build (skip clean)
+.\github\scripts\verify-compilation.ps1
 ```
 
 ### Configuring your local Unreal Engine path
@@ -29,13 +32,11 @@ Create a repo-local, gitignored file in repo root: `unreal-dev-settings.json`
 { "unreal_engine_path": "C:\\Program Files\\Epic Games\\UE_5.5" }
 ```
 
-`scripts/verify-compile.ps1` reads this file automatically.
+`.github\scripts\verify-compilation.ps1` reads this file automatically.
 
 ### Outputs
-- Build output: `tmp/build/`
-- Log file: `tmp/logs/UAT-BuildPlugin.log`
-
-Note: `tmp/` is intentionally gitignored and should never be committed.
+- Build output: `Build~\PluginBuild\`
+- Log file: `Build~\UAT.log`
 
 ## B) CI compile verification (GitHub Actions)
 

--- a/.github/scripts/verify-compilation.ps1
+++ b/.github/scripts/verify-compilation.ps1
@@ -1,0 +1,231 @@
+#Requires -Version 5.0
+<#
+.SYNOPSIS
+    Verifies that the LootLocker Unreal Server SDK plugin compiles without errors.
+
+.DESCRIPTION
+    Reads unreal-dev-settings.json from the repo root, locates the plugin's
+    .uplugin file, then runs Unreal's RunUAT BuildPlugin in batch mode to
+    check that the plugin compiles cleanly on the local machine.
+
+    See .github/instructions/verification.md for setup instructions.
+
+.PARAMETER Clean
+    Delete the previous build output and plugin Intermediate/Binaries before
+    building. Omit for a faster incremental build (UAT reuses cached artifacts).
+
+.NOTES
+    Exit codes: 0 = compilation succeeded, 1 = compilation failed or setup error.
+#>
+param(
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot   = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$SettingsFile = Join-Path $RepoRoot "unreal-dev-settings.json"
+# Use a short temp path for build output to avoid Windows MAX_PATH (260 char)
+# issues with the server SDK's long filenames (e.g. LootLockerServerLeaderboardArchiveRequestHandler.cpp).
+$BuildOutput  = Join-Path $env:TEMP "LLServerSdkBuild"
+$LogFile      = Join-Path $RepoRoot "Build~\UAT.log"
+
+function Write-Step { param([string]$Msg) Write-Host $Msg }
+function Write-Ok   { param([string]$Msg) Write-Host $Msg -ForegroundColor Green }
+function Write-Fail { param([string]$Msg) Write-Host $Msg -ForegroundColor Red }
+function Write-Warn { param([string]$Msg) Write-Host $Msg -ForegroundColor Yellow }
+
+Write-Step "==========================================="
+Write-Step "  LootLocker Unreal Server SDK - Compile Check"
+Write-Step "==========================================="
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 1. Load settings
+# ---------------------------------------------------------------------------
+if (-not (Test-Path $SettingsFile)) {
+    Write-Warn "SETUP REQUIRED: 'unreal-dev-settings.json' not found at repo root."
+    Write-Step ""
+    Write-Step "Create the file with the following content:"
+    Write-Step '  { "unreal_engine_path": "C:\\Program Files\\Epic Games\\UE_5.5" }'
+    Write-Step ""
+    Write-Step "See .github/instructions/verification.md for details."
+    exit 1
+}
+
+$Settings      = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+$UnrealRoot    = $Settings.unreal_engine_path
+
+if ([string]::IsNullOrWhiteSpace($UnrealRoot)) {
+    Write-Fail "ERROR: 'unreal_engine_path' is empty in unreal-dev-settings.json."
+    exit 1
+}
+if (-not (Test-Path $UnrealRoot)) {
+    Write-Fail "ERROR: Unreal Engine path not found: $UnrealRoot"
+    exit 1
+}
+
+$RunUAT = Join-Path $UnrealRoot "Engine\Build\BatchFiles\RunUAT.bat"
+if (-not (Test-Path $RunUAT)) {
+    Write-Fail "ERROR: RunUAT.bat not found at: $RunUAT"
+    Write-Step "       Check that 'unreal_engine_path' points to the UE install root."
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# 2. Locate the plugin uplugin file
+# ---------------------------------------------------------------------------
+$PluginFile = Get-ChildItem -Path $RepoRoot -Filter "*.uplugin" -Recurse -Depth 2 |
+              Where-Object { $_.FullName -notlike "*\Build~\*" } |
+              Select-Object -First 1
+
+if (-not $PluginFile) {
+    Write-Fail "ERROR: No .uplugin file found under $RepoRoot"
+    exit 1
+}
+
+Write-Step "Plugin  : $($PluginFile.FullName)"
+Write-Step "Engine  : $UnrealRoot"
+Write-Step "Output  : $BuildOutput"
+Write-Step "Log     : $LogFile"
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 3. Prepare output directories and clear stale log
+# ---------------------------------------------------------------------------
+if ($Clean) {
+    if (Test-Path $BuildOutput) {
+        Write-Step "Cleaning previous build output..."
+        & cmd /c "rmdir /S /Q `"$BuildOutput`"" 2>&1 | Out-Null
+        if (Test-Path $BuildOutput) {
+            Write-Warn "Warning: Could not fully remove previous build output at $BuildOutput - UAT will attempt to overwrite it."
+        }
+    }
+} elseif (Test-Path $BuildOutput) {
+    Write-Step "Reusing existing build output (pass -Clean to force a full rebuild)."
+}
+$LogDir = Split-Path $LogFile
+if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir -Force | Out-Null }
+if (Test-Path $LogFile) { Remove-Item $LogFile -Force }
+
+# Clear the plugin's Intermediate and Binaries directories before UAT runs.
+if ($Clean) {
+    foreach ($staleDir in @("Intermediate", "Binaries")) {
+        $dirPath = Join-Path (Split-Path $PluginFile.FullName) $staleDir
+        if (Test-Path $dirPath) {
+            Write-Step "Clearing plugin $staleDir directory before UAT copy..."
+            & cmd /c "rmdir /S /Q `"$dirPath`"" 2>&1 | Out-Null
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 4. Temporarily disable UBA local execution
+# ---------------------------------------------------------------------------
+$UbtConfigDir = Join-Path $env:APPDATA "Unreal Engine\UnrealBuildTool"
+$UbtConfigFile = Join-Path $UbtConfigDir "BuildConfiguration.xml"
+$UbtConfigBackup = $UbtConfigFile + ".verify-compilation-backup"
+$WroteUbtConfig = $false
+
+if (-not (Test-Path $UbtConfigDir)) { New-Item -ItemType Directory -Path $UbtConfigDir -Force | Out-Null }
+
+if (Test-Path $UbtConfigFile) {
+    Copy-Item $UbtConfigFile $UbtConfigBackup -Force
+}
+
+$noUbaXml = @'
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+  <BuildConfiguration>
+    <bAllowUBAExecutor>false</bAllowUBAExecutor>
+    <bAllowUBALocalExecutor>false</bAllowUBALocalExecutor>
+    <bAllowUBALocalExecutor>false</bAllowUBALocalExecutor>
+  </BuildConfiguration>
+</Configuration>
+'@
+[IO.File]::WriteAllText($UbtConfigFile, $noUbaXml)
+$WroteUbtConfig = $true
+
+$env:UnrealBuildTool_BuildConfiguration__bAllowUBAExecutor = "false"
+
+# Kill any lingering dotnet processes from previous crashed builds.
+Get-CimInstance Win32_Process -Filter "Name = 'dotnet.exe'" -ErrorAction SilentlyContinue |
+    Where-Object { $_.CommandLine -like "*UnrealBuildTool.dll*" } |
+    ForEach-Object {
+        Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+
+Write-Step "Note: Disabled UBA local executor to avoid UbaDetours/rc.exe crash (restored after build)."
+Write-Step ""
+
+# ---------------------------------------------------------------------------
+# 5. Run RunUAT BuildPlugin
+# ---------------------------------------------------------------------------
+Write-Step "Running: RunUAT BuildPlugin (Win64, this may take a few minutes on a cold cache) ..."
+Write-Step ""
+
+$uatArgs = @(
+    "BuildPlugin"
+    "-Plugin=`"$($PluginFile.FullName)`""
+    "-Package=`"$BuildOutput`""
+    "-Rocket"
+    "-TargetPlatforms=Win64"
+    "-VS2022"
+)
+
+$prevEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+
+$uatOutput = [System.Collections.Generic.List[string]]::new()
+$logStream = [System.IO.StreamWriter]::new($LogFile, $false, [System.Text.Encoding]::UTF8)
+try {
+    & $RunUAT @uatArgs 2>&1 | ForEach-Object {
+        $line = "$_"
+        $uatOutput.Add($line)
+        $logStream.WriteLine($line)
+        $logStream.Flush()
+        Write-Host $line
+    }
+} finally {
+    $logStream.Close()
+
+    if ($WroteUbtConfig) {
+        if (Test-Path $UbtConfigBackup) {
+            Move-Item $UbtConfigBackup $UbtConfigFile -Force
+        } else {
+            Remove-Item $UbtConfigFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Remove-Item Env:\UnrealBuildTool_BuildConfiguration__bAllowUBAExecutor -ErrorAction SilentlyContinue
+}
+$script:uat_exit = $LASTEXITCODE
+
+$ErrorActionPreference = $prevEAP
+
+# ---------------------------------------------------------------------------
+# 6. Report results
+# ---------------------------------------------------------------------------
+Write-Step ""
+Write-Step "--- Compilation result ---"
+Write-Step ""
+
+$compilerErrors = $uatOutput | Select-String -Pattern "error C\d+|error LNK\d+|Error:|Deprecation:|Result: Failed" | Select-String -NotMatch "0 error\(s\)|not a preferred version"
+if ($compilerErrors) {
+    $compilerErrors | ForEach-Object { Write-Host $_.Line }
+    Write-Step ""
+}
+
+Write-Step "----------------------------------"
+Write-Step ""
+
+if ($script:uat_exit -eq 0) {
+    Write-Ok "COMPILATION SUCCEEDED"
+}
+else {
+    $failureLine = $uatOutput | Select-String -Pattern "BUILD FAILED|Failed to build|ExitCode=\d+" | Select-Object -First 1
+    $reason = if ($failureLine) { $failureLine.Line.Trim() } else { "exit code: $script:uat_exit" }
+    Write-Fail "COMPILATION FAILED ($reason)"
+    Write-Step "Full log: $LogFile"
+    exit 1
+}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,159 @@
+name: Create Release
+run-name: "Create Release from ${{ github.ref_name }}"
+
+on:
+  workflow_run:
+    workflows: ["Verify compile (quick)"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to pull release notes from (e.g. 123)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: |
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Find merged PR that triggered this push (or use dispatch input)
+        id: find-pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ inputs.pr_number }}"
+            echo "Manual dispatch - fetching PR #${PR_NUMBER}"
+          else
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            echo "Looking up PR for commit ${HEAD_SHA}"
+            PR_NUMBER=$(gh pr list \
+              --search "${HEAD_SHA}" \
+              --state merged \
+              --json number \
+              --limit 1 \
+              --jq '.[0].number')
+          fi
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::notice::No PR found. Not a release-eligible push."
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json number,body,labels,title,state --jq '.')
+          PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+          HAS_RC_LABEL=$(echo "$PR_JSON" | jq -r '[.labels[].name] | index("release candidate") != null')
+
+          echo "Found PR #${PR_NUMBER}: ${PR_TITLE}"
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          if [ "$HAS_RC_LABEL" != "true" ]; then
+            echo "::notice::PR #${PR_NUMBER} does not have 'release candidate' label. Skipping release."
+            echo "IS_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "$PR_JSON" | jq -r '.body' > /tmp/pr-body.md
+          echo "IS_RELEASE=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate release notes (PR body is non-empty)
+        id: validate
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          if [ ! -s /tmp/pr-body.md ]; then
+            echo "::error::PR body is empty. Release notes are required."
+            exit 1
+          fi
+          echo "Release notes found ($(wc -c < /tmp/pr-body.md) bytes)."
+
+      - name: Read version from .uplugin
+        id: version
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerServerSDK/LootLockerServerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          TAG="v${VERSION}"
+          echo "TAG=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Version: ${VERSION} -> Tag: ${TAG}"
+
+      - name: Check tag does not already exist
+        id: check-tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists. Version must be bumped."
+            exit 1
+          fi
+          echo "Tag ${TAG} is available."
+
+      - name: Validate version bump against latest tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+          NEW_VERSION="${{ steps.version.outputs.VERSION }}"
+          compare_versions() { echo "$1" | awk -F. '{ printf "%d%03d%03d", $1, $2, $3 }'; }
+          OLD_CMP=$(compare_versions "$LATEST_VERSION")
+          NEW_CMP=$(compare_versions "$NEW_VERSION")
+          if [ "$OLD_CMP" -ge "$NEW_CMP" ]; then
+            echo "::error::Version $NEW_VERSION is not greater than latest release $LATEST_VERSION."
+            exit 1
+          fi
+          echo "Version bump validated: ${LATEST_VERSION} -> ${NEW_VERSION}"
+
+      - name: Create git tag
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Pushed tag ${TAG}"
+
+      - name: Create GitHub Release
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          TITLE="LootLocker_UnrealServerSDK_V${VERSION}"
+          gh release create "$TAG" \
+            --title "$TITLE" \
+            --notes-file /tmp/pr-body.md \
+            --target main
+          echo "Created release ${TAG}"
+        env:
+          GH_TOKEN: ${{ secrets.UNREAL_CI_PERSONAL_ACCESS_TOKEN }}
+
+      - name: Post release notification on PR
+        if: steps.find-pr.outputs.IS_RELEASE == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.TAG }}"
+          PR_NUMBER="${{ steps.find-pr.outputs.PR_NUMBER }}"
+          REPO="${{ github.repository }}"
+          printf -v BODY '**Release [%s](https://github.com/%s/releases/tag/%s) created.**\n\nWorkflows now running:\n- [Package SDK](https://github.com/%s/actions/workflows/unreal-server-sdk-packager.yml) - builds and attaches packages\n- [Generate Docs](https://github.com/%s/actions/workflows/generate-docs.yml) - deploys reference docs' \
+            "$TAG" "$REPO" "$TAG" "$REPO" "$REPO"
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,7 +3,7 @@ run-name: "Create Release from ${{ github.ref_name }}"
 
 on:
   workflow_run:
-    workflows: ["Verify compile (quick)"]
+    workflows: ["Build plugin using unreal conainer"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/enforce-release-pr.yml
+++ b/.github/workflows/enforce-release-pr.yml
@@ -1,0 +1,130 @@
+name: Enforce Release PR
+run-name: "Enforce release candidate PR requirements"
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  enforce:
+    name: Validate release candidate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    if: contains(github.event.pull_request.labels.*.name, 'release candidate')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate PR body structure
+        id: check-body
+        run: |
+          BODY=$(jq -r '.pull_request.body // ""' < "$GITHUB_EVENT_PATH")
+          if [ -z "$(echo "$BODY" | tr -d '[:space:]')" ]; then
+            echo "::error::PR body is empty. Release notes are required."
+            echo "BODY_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "BODY_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$BODY" | grep -q '^### '; then
+            echo "HAS_SECTIONS=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::PR body must have at least one section header (### Features, ### Fixes, etc.)."
+            echo "HAS_SECTIONS=false" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$BODY" | grep -qi 'Full Changelog:'; then
+            echo "HAS_CHANGELOG_LINK=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PR body is missing a Full Changelog: compare link."
+            echo "HAS_CHANGELOG_LINK=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read version from .uplugin
+        id: version
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerServerSDK/LootLockerServerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current version in branch: ${VERSION}"
+
+      - name: Get latest release tag
+        id: latest-tag
+        run: |
+          LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // "v0.0.0"')
+          echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Latest release tag: ${LATEST_TAG}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Validate version bump
+        id: check-version
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.VERSION }}"
+          LATEST_TAG="${{ steps.latest-tag.outputs.TAG }}"
+          LATEST_VERSION=$(echo "$LATEST_TAG" | sed 's/^v//')
+          compare_versions() { echo "$1" | awk -F. '{ printf "%d%03d%03d", $1, $2, $3 }'; }
+          OLD_CMP=$(compare_versions "$LATEST_VERSION")
+          NEW_CMP=$(compare_versions "$NEW_VERSION")
+          if [ "$OLD_CMP" -ge "$NEW_CMP" ]; then
+            echo "::error::Version ${NEW_VERSION} is not greater than latest release ${LATEST_VERSION}."
+            echo "VERSION_OK=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version bump OK: ${LATEST_VERSION} -> ${NEW_VERSION}"
+            echo "VERSION_OK=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report and post status comment
+        if: always()
+        run: |
+          VERSION_OK="${{ steps.check-version.outputs.VERSION_OK }}"
+          BODY_OK="${{ steps.check-body.outputs.BODY_OK }}"
+          HAS_SECTIONS="${{ steps.check-body.outputs.HAS_SECTIONS }}"
+          HAS_CHANGELOG_LINK="${{ steps.check-body.outputs.HAS_CHANGELOG_LINK }}"
+          VERSION="${{ steps.version.outputs.VERSION }}"
+
+          issues=""
+          if [ "$VERSION_OK" != "true" ]; then
+            issues="${issues}\\n- Version not bumped. Latest release is ${{ steps.latest-tag.outputs.TAG }} but this PR has v${VERSION}."
+          fi
+          if [ "$BODY_OK" != "true" ]; then
+            issues="${issues}\\n- PR body is empty. Add release notes to the PR description."
+          fi
+          if [ "$HAS_SECTIONS" != "true" ]; then
+            issues="${issues}\\n- No section headers found. Add at least one ### section."
+          fi
+          warnings=""
+          if [ "$HAS_CHANGELOG_LINK" != "true" ]; then
+            warnings="${warnings}\\n- Missing Full Changelog link - consider adding one."
+          fi
+
+          if [ -n "$issues" ]; then
+            printf "### Release PR Validation Failed\n${issues}${warnings}\n" > /tmp/status.md
+          else
+            printf "### Release PR Validation Passed\n\n- Version: **v${VERSION}** (bumped from ${{ steps.latest-tag.outputs.TAG }})\n- Release notes: present (section headers found)" > /tmp/status.md
+            if [ "$HAS_CHANGELOG_LINK" = "true" ]; then printf ", changelog link present" >> /tmp/status.md; fi
+            printf "\n" >> /tmp/status.md
+          fi
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("### Release PR Validation")) | .id' | head -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              --field body="$(cat /tmp/status.md)"
+          else
+            gh pr comment "$PR_NUMBER" --body "$(cat /tmp/status.md)"
+          fi
+          if [ -n "$issues" ]; then exit 1; fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/enforce-release-pr.yml
+++ b/.github/workflows/enforce-release-pr.yml
@@ -4,7 +4,7 @@ run-name: "Enforce release candidate PR requirements"
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, labeled]
+    types: [opened, synchronize, labeled, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -54,6 +54,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download docs artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -2,12 +2,6 @@ name: Generate Docs
 run-name: "Generate Docs on ${{ github.ref_name }}"
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - synchronize
   release:
     types: [published]
   workflow_dispatch: {}

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -41,16 +41,20 @@ jobs:
         id: current
         run: |
           VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerServerSDK/LootLockerServerSDK.uplugin)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read VersionName from .uplugin"
+            exit 1
+          fi
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Current version: ${VERSION}"
 
       - name: Get previous release tag and commit log
         id: prev-tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Previous tag: ${LATEST_TAG:-none}"
-          if [ -n "$LATEST_TAG" ]; then
+          echo "Previous tag: ${LATEST_TAG}"
+          if [ "$LATEST_TAG" != "v0.0.0" ]; then
             REV_RANGE="${LATEST_TAG}..HEAD"
           else
             REV_RANGE="HEAD"
@@ -77,23 +81,24 @@ jobs:
           if [ "$BUMP" = "auto" ] && [ "$ALREADY_CALCULATED" = "false" ]; then
             echo "Auto-detecting version from OpenRouter..."
             if [ -z "${{ secrets.OPENROUTER_API_KEY }}" ]; then
-              echo "::error::OPENROUTER_API_KEY secret not set. Use manual bump or set secret."
-              exit 1
+              echo "::warning::OPENROUTER_API_KEY not set. Falling back to patch bump."
+              BUMP="patch"
+            else
+              COMMITS=$(head -100 /tmp/commits.log)
+              printf 'The current version is v%s. Based on these commit messages since the last release, determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 1.1.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
+              RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+                -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+                -H "Content-Type: application/json" \
+                -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
+              NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+              if [ -z "$NEW" ]; then
+                echo "::warning::AI returned no parseable version. Falling back to patch bump."
+                BUMP="patch"
+              else
+                echo "AI suggested version: ${NEW}"
+                ALREADY_CALCULATED=true
+              fi
             fi
-            COMMITS=$(head -100 /tmp/commits.log)
-            printf 'Based on these commit messages since the last release (v%s), determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 1.1.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
-            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
-              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
-              -H "Content-Type: application/json" \
-              -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
-            NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-            if [ -z "$NEW" ]; then
-              echo "::warning::AI returned no parseable version, falling back to patch bump."
-              PATCH=$(echo "$CURRENT" | cut -d. -f3)
-              NEW="$(echo "$CURRENT" | cut -d. -f1).$(echo "$CURRENT" | cut -d. -f2).$((PATCH + 1))"
-            fi
-            echo "AI suggested version: ${NEW}"
-            ALREADY_CALCULATED=true
           fi
 
           if [ "$ALREADY_CALCULATED" = "false" ]; then

--- a/.github/workflows/open-release-pr.yml
+++ b/.github/workflows/open-release-pr.yml
@@ -1,0 +1,179 @@
+name: Open Release PR
+run-name: "Open release candidate PR for ${{ inputs.bump }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Type of version bump
+        required: true
+        type: choice
+        options:
+          - auto
+          - major
+          - minor
+          - patch
+        default: auto
+      custom_version:
+        description: Custom version override (e.g. 1.1.0). Leave empty to use semver bump.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  open-pr:
+    name: Create release candidate PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout dev
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Read current version
+        id: current
+        run: |
+          VERSION=$(sed -n -r 's/^ +"VersionName": "([0-9]+\.[0-9]+\.[0-9]+)",/\1/p' LootLockerServerSDK/LootLockerServerSDK.uplugin)
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Current version: ${VERSION}"
+
+      - name: Get previous release tag and commit log
+        id: prev-tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "TAG=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${LATEST_TAG:-none}"
+          if [ -n "$LATEST_TAG" ]; then
+            REV_RANGE="${LATEST_TAG}..HEAD"
+          else
+            REV_RANGE="HEAD"
+          fi
+          git log "$REV_RANGE" --format="%s" > /tmp/commits.log
+          COMMIT_COUNT=$(wc -l < /tmp/commits.log)
+          echo "Commits: ${COMMIT_COUNT}"
+          echo "COMMIT_COUNT=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate new version
+        id: new-version
+        run: |
+          CURRENT="${{ steps.current.outputs.VERSION }}"
+          CUSTOM="${{ inputs.custom_version }}"
+          BUMP="${{ inputs.bump }}"
+          ALREADY_CALCULATED=false
+
+          if [ -n "$CUSTOM" ]; then
+            NEW="$CUSTOM"
+            echo "Using custom version: ${NEW}"
+            ALREADY_CALCULATED=true
+          fi
+
+          if [ "$BUMP" = "auto" ] && [ "$ALREADY_CALCULATED" = "false" ]; then
+            echo "Auto-detecting version from OpenRouter..."
+            if [ -z "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+              echo "::error::OPENROUTER_API_KEY secret not set. Use manual bump or set secret."
+              exit 1
+            fi
+            COMMITS=$(head -100 /tmp/commits.log)
+            printf 'Based on these commit messages since the last release (v%s), determine the correct semver version for the next release. Analyze breaking changes, new features, and fixes. Respond with only the version number (e.g., 1.1.0).\n\n%s\n' "$CURRENT" "$COMMITS" > /tmp/version-prompt.txt
+            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --rawfile prompt /tmp/version-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"low"},max_tokens:2000,temperature:0}')")
+            NEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            if [ -z "$NEW" ]; then
+              echo "::warning::AI returned no parseable version, falling back to patch bump."
+              PATCH=$(echo "$CURRENT" | cut -d. -f3)
+              NEW="$(echo "$CURRENT" | cut -d. -f1).$(echo "$CURRENT" | cut -d. -f2).$((PATCH + 1))"
+            fi
+            echo "AI suggested version: ${NEW}"
+            ALREADY_CALCULATED=true
+          fi
+
+          if [ "$ALREADY_CALCULATED" = "false" ]; then
+            BUMP="${{ inputs.bump }}"
+            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+            MINOR=$(echo "$CURRENT" | cut -d. -f2)
+            PATCH=$(echo "$CURRENT" | cut -d. -f3)
+            case "$BUMP" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH + 1)) ;;
+            esac
+            NEW="${MAJOR}.${MINOR}.${PATCH}"
+            echo "Bumped ${CURRENT} -> ${NEW} (${BUMP})"
+          fi
+
+          echo "TAG=v${NEW}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${NEW}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in .uplugin
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          sed -i -r 's/^(\s+"VersionName":\s*)"[0-9]+\.[0-9]+\.[0-9]+"/\1"'"${NEW_VERSION}"'"/' LootLockerServerSDK/LootLockerServerSDK.uplugin
+          echo "Updated .uplugin version to ${NEW_VERSION}"
+
+      - name: Create branch and commit
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          BRANCH="release/v${NEW_VERSION}"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
+          git add LootLockerServerSDK/LootLockerServerSDK.uplugin
+          git commit -m "Bump version to ${NEW_VERSION}"
+          git push origin "$BRANCH"
+          echo "BRANCH=${BRANCH}" >> "$GITHUB_ENV"
+
+      - name: Generate release notes
+        run: |
+          PREV="${{ steps.prev-tag.outputs.TAG }}"
+          NEW_TAG="${{ steps.new-version.outputs.TAG }}"
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          COMMITS=$(cat /tmp/commits.log)
+          echo "::group::Commits since ${PREV:-beginning}"
+          echo "$COMMITS"
+          echo "::endgroup::"
+
+          if [ -n "${{ secrets.OPENROUTER_API_KEY }}" ]; then
+            echo "Generating release notes via OpenRouter..."
+            printf 'You are writing release notes for LootLocker Unreal Server SDK version %s.\n\nBelow are the commit messages since the last release. Write concise, user-facing release notes following this template exactly. Only include sections that have content. Keep the audience in mind: Unreal Engine server-side developers using LootLocker.\n\nTemplate:\n### Features\n- Feature Title - Description of what the developer can now do.\n\n### Fixes\n- Fixed an issue where X would happen when Y.\n\n### Breaking Changes\n- Removed / changed API - explain migration.\n\nFull Changelog: [%s...%s](https://github.com/lootlocker/unreal-server-sdk/compare/%s...%s)\n\nCommit messages:\n%s\n' "$NEW_VERSION" "$PREV" "$NEW_TAG" "$PREV" "$NEW_TAG" "$COMMITS" > /tmp/ai-prompt.txt
+            RESPONSE=$(curl -s "https://openrouter.ai/api/v1/chat/completions" \
+              -H "Authorization: Bearer ${{ secrets.OPENROUTER_API_KEY }}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --rawfile prompt /tmp/ai-prompt.txt '{model:"deepseek/deepseek-v4-pro",messages:[{role:"user",content:$prompt}],reasoning:{effort:"medium"},max_tokens:8000,temperature:0.3}')")
+            NOTES=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // ""')
+            if [ -n "$NOTES" ] && [ "$NOTES" != "null" ]; then
+              echo "$NOTES" > /tmp/release-notes.md
+              echo "AI-generated release notes."
+            else
+              echo "::warning::OpenRouter returned empty response, falling back to template."
+              NOTES=""
+            fi
+          fi
+
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Using static template."
+            printf '### Features\n\n- Feature Title - Description.\n\n### Fixes\n\n- Fixed ...\n\nFull Changelog: [%s...%s](https://github.com/lootlocker/unreal-server-sdk/compare/%s...%s)\n' "$PREV" "$NEW_TAG" "$PREV" "$NEW_TAG" > /tmp/release-notes.md
+          fi
+          echo "Release notes generated."
+
+      - name: Create PR
+        run: |
+          NEW_VERSION="${{ steps.new-version.outputs.VERSION }}"
+          TITLE="Release v${NEW_VERSION}"
+          gh pr create \
+            --title "$TITLE" \
+            --body "$(cat /tmp/release-notes.md)" \
+            --base main \
+            --head "$BRANCH" \
+            --label "release candidate" \
+            --reviewer "kirre-bylund"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/unreal-server-sdk-packager.yml
+++ b/.github/workflows/unreal-server-sdk-packager.yml
@@ -1,12 +1,6 @@
 name: Unreal Server SDK Packager
 run-name: sdk-packager
 on:
-  push:
-      branches:
-        - main
-        - ci/*
-      tags:
-        - v**
   release:
     types: [published]
   workflow_dispatch: {}

--- a/.github/workflows/unreal-server-sdk-packager.yml
+++ b/.github/workflows/unreal-server-sdk-packager.yml
@@ -2,12 +2,17 @@ name: Unreal Server SDK Packager
 run-name: sdk-packager
 on:
   push:
-      branches: # Made towards the following
+      branches:
         - main
         - ci/*
       tags:
         - v**
+  release:
+    types: [published]
   workflow_dispatch: {}
+
+permissions:
+  contents: write
 
 jobs: 
   package-sdk:
@@ -30,6 +35,8 @@ jobs:
           SDK_PATH="$(pwd)"
           SDK_NAME=`find "$SDK_PATH" -type f -name "*.uplugin" | sed -n -r "s/.*\/([-A-Za-z0-9_]+)\.uplugin/\1/p"`
           SDK_VERSION=`sed -n -r 's/^ +\"VersionName\": \"([0-9]+.[0-9]+.[0-9]+)\",/\1/p' < "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"`
+          echo "SDK_PATH=${SDK_PATH}" >> $GITHUB_ENV
+          echo "SDK_NAME=${SDK_NAME}" >> $GITHUB_ENV
           sed -i -r "s/^( +)(\"VersionName\": \"[0-9\.]+\",)/\1\2\n\1\"EngineVersion\": \"${{ matrix.UE_VERSION }}\",/g" "$SDK_PATH/$SDK_NAME/$SDK_NAME.uplugin"
           CURRENT_PACKAGE_DIR="Packaged"
           echo "PACKAGE_DIR=${CURRENT_PACKAGE_DIR}" >> $GITHUB_ENV
@@ -44,4 +51,12 @@ jobs:
         with:
           name: ${{ ENV.PACKAGE_NAME }}
           path: ${{ ENV.PACKAGE_DIR }}/${{ ENV.PACKAGE_NAME }}
+
+      - name: Attach package to release
+        if: github.event_name == 'release'
+        run: |
+          cd "$SDK_PATH"
+          gh release upload --clobber "${{ github.ref_name }}" "$PACKAGE_DIR/$PACKAGE_NAME"
+        env:
+          GH_TOKEN: ${{ secrets.UNREAL_CI_PERSONAL_ACCESS_TOKEN }}
           

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ unreal-dev-settings.json
 
 # Doxygen generated output
 docs/
+
+# Ignore config files
+LootLockerServerSDK/Config/*.bytes

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ DemoProject/DerivedDataCache/*
 _codeql_*
 
 # Local compile verification output
+Build~/
 tmp/
 Temp~/
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ LootLockerServerSDK/Intermediate/*
 
 # Builds
 Build/*
+Build~
 
 # Whitelist PakBlacklist-<BuildConfiguration>.txt files
 !Build/*/

--- a/LootLockerServerSDK/LootLockerServerSDK.uplugin
+++ b/LootLockerServerSDK/LootLockerServerSDK.uplugin
@@ -2,7 +2,7 @@
     "FileVersion": 3,
     "FriendlyName": "LootLockerServerSDK",
     "Version": 15,
-    "VersionName": "6.5.0",
+    "VersionName": "6.6.0",
     "CreatedBy": "LootLocker",
     "CreatedByURL": "https://www.lootlocker.com/",
     "DocsURL": "https://docs.lootlocker.com/",

--- a/LootLockerServerSDK/LootLockerServerSDK.uplugin
+++ b/LootLockerServerSDK/LootLockerServerSDK.uplugin
@@ -1,7 +1,7 @@
 {
     "FileVersion": 3,
     "FriendlyName": "LootLockerServerSDK",
-    "Version": 15,
+    "Version": 16,
     "VersionName": "6.6.0",
     "CreatedBy": "LootLocker",
     "CreatedByURL": "https://www.lootlocker.com/",

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
@@ -3,15 +3,17 @@
 #include "LootLockerServerConfig.h"
 #include "Misc/Paths.h"
 #include "Misc/DateTime.h"
+#include "Misc/FileHelper.h"
+#include "Interfaces/IPluginManager.h"
+#include "JsonObjectConverter.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Misc/AES.h"
+#include "Misc/Base64.h"
 
 namespace {
     static bool bRuntimeLogLevelOverrideSet = false;
     static ELootLockerServerLogLevel RuntimeLogLevelOverride = ELootLockerServerLogLevel::Ignore;
-}
-
-ULootLockerServerConfig::ULootLockerServerConfig()
-{
-    LimitLogLevelTo = ELootLockerServerLogLevel::Warning;
 }
 
 void ULootLockerServerConfig::SetRuntimeLogLevel(ELootLockerServerLogLevel NewLevel)
@@ -70,4 +72,192 @@ FString ULootLockerServerConfig::GetLogFilePath()
 {
     const ULootLockerServerConfig* Config = GetDefault<ULootLockerServerConfig>();
     return Config->LogFilePath;
+}
+
+// ========================================================================
+// FILE CONFIG IMPLEMENTATION
+// ========================================================================
+
+bool ULootLockerServerConfig::IsFileConfigActive()
+{
+    if (!bFileConfigChecked)
+    {
+        GetDefault<ULootLockerServerConfig>()->LoadFileConfig();
+    }
+    return FileConfig.IsSet();
+}
+
+// Hardcoded decryption key for pre-config files.
+// This is intentionally embedded rather than configurable — the scheme is only meant to
+// keep the API key out of casual plain-text searches, not to provide cryptographic security.
+inline static const FAES::FAESKey GetServerFileConfigDecryptionKey()
+{
+    static const uint8 KeyBytes[32] = {
+        0x4C, 0x6F, 0x6F, 0x74, 0x4C, 0x6F, 0x63, 0x6B,
+        0x65, 0x72, 0x53, 0x65, 0x72, 0x76, 0x65, 0x72,
+        0x50, 0x72, 0x65, 0x43, 0x6F, 0x6E, 0x66, 0x69,
+        0x67, 0x4B, 0x65, 0x79, 0x32, 0x30, 0x32, 0x35
+    };
+    FAES::FAESKey Key;
+    FMemory::Memcpy(Key.Key, KeyBytes, 32);
+    return Key;
+}
+
+TOptional<FLootLockerServerFileConfig> ULootLockerServerConfig::ParseFileConfigContent(const FString& Content)
+{
+    if (Content.IsEmpty())
+    {
+        return {};
+    }
+
+    FString JsonString;
+
+    // Try plain JSON first
+    TSharedPtr<FJsonObject> JsonObject;
+    TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+    if (FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
+    {
+        JsonString = Content;
+    }
+    else
+    {
+        // Try AES-256-ECB + PKCS7 + Base64 decryption
+        TArray<uint8> EncryptedData;
+        if (!FBase64::Decode(Content, EncryptedData))
+        {
+            return {};
+        }
+
+        const FAES::FAESKey DecryptionKey = GetServerFileConfigDecryptionKey();
+        FAES::DecryptData(EncryptedData.GetData(), EncryptedData.Num(), DecryptionKey);
+
+        // Remove PKCS7 padding
+        if (EncryptedData.Num() > 0)
+        {
+            const uint8 PaddingValue = EncryptedData.Last();
+            if (PaddingValue > 0 && PaddingValue <= 16 && PaddingValue <= EncryptedData.Num())
+            {
+                bool bValidPadding = true;
+                for (int32 i = 1; i <= PaddingValue; ++i)
+                {
+                    if (EncryptedData[EncryptedData.Num() - i] != PaddingValue)
+                    {
+                        bValidPadding = false;
+                        break;
+                    }
+                }
+                if (bValidPadding)
+                {
+                    EncryptedData.SetNum(EncryptedData.Num() - PaddingValue);
+                }
+            }
+        }
+
+        // Convert decrypted bytes to UTF-8 string
+        JsonString = FString(EncryptedData.Num(), UTF8_TO_TCHAR(reinterpret_cast<const char*>(EncryptedData.GetData())));
+
+        // Re-parse the decrypted JSON
+        Reader = TJsonReaderFactory<>::Create(JsonString);
+        if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+        {
+            return {};
+        }
+    }
+
+    FLootLockerServerFileConfig Config;
+    if (!FJsonObjectConverter::JsonObjectToUStruct(JsonObject.ToSharedRef(), &Config, 0, 0))
+    {
+        return {};
+    }
+
+    // api_key is the gating field — empty or missing means "inactive"
+    if (Config.api_key.IsEmpty())
+    {
+        return {};
+    }
+
+    return Config;
+}
+
+void ULootLockerServerConfig::LoadFileConfig()
+{
+    if (bFileConfigChecked)
+    {
+        return;
+    }
+
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(*PluginName);
+    if (!Plugin.IsValid())
+    {
+        bFileConfigChecked = true;
+        return;
+    }
+
+    // Build filename: PackageName + "ServerPreConfig" + optional "-" + ConfigFileIdentifier + ".bytes"
+    FString FileName = PackageName + TEXT("ServerPreConfig");
+    if (!ConfigFileIdentifier.IsEmpty())
+    {
+        FileName += TEXT("-") + ConfigFileIdentifier;
+    }
+    FileName += TEXT(".bytes");
+
+    const FString FilePath = FPaths::Combine(Plugin->GetBaseDir(), TEXT("Config"), FileName);
+
+    FString Content;
+    if (!FFileHelper::LoadFileToString(Content, *FilePath))
+    {
+        bFileConfigChecked = true;
+        return;
+    }
+
+    FileConfig = ParseFileConfigContent(Content);
+    bFileConfigChecked = true;
+}
+
+void ULootLockerServerConfig::ApplyFileConfigIfPresent()
+{
+    if (!FileConfig.IsSet())
+    {
+        ULootLockerServerConfig* Default = GetMutableDefault<ULootLockerServerConfig>();
+        Default->bIsFileConfigLocked = false;
+        return;
+    }
+
+    const FLootLockerServerFileConfig& FC = FileConfig.GetValue();
+    ULootLockerServerConfig* Config = GetMutableDefault<ULootLockerServerConfig>();
+
+    Config->LootLockerServerKey = FC.api_key;
+    if (!FC.domain_key.IsEmpty())
+    {
+        Config->LootLockerDomainKey = FC.domain_key;
+    }
+    if (!FC.game_version.IsEmpty())
+    {
+        Config->GameVersion = FC.game_version;
+    }
+    Config->IsValidGameVersion = IsSemverString(Config->GameVersion);
+    Config->LogOutsideOfEditor = FC.log_outside_of_editor;
+
+    // Map log_level enum string -> ELootLockerServerLogLevel
+    if (!FC.log_level.IsEmpty())
+    {
+        const UEnum* Enum = StaticEnum<ELootLockerServerLogLevel>();
+        const int64 Value = Enum->GetValueByNameString(FC.log_level);
+        if (Value != INDEX_NONE)
+        {
+            Config->LimitLogLevelTo = static_cast<ELootLockerServerLogLevel>(Value);
+        }
+    }
+
+    Config->bEnableFileLogging = FC.enable_file_logging;
+    Config->bIsFileConfigLocked = true;
+
+    if (Config->bEnableFileLogging)
+    {
+        EnableFileLogging(Config->LogFileName.IsEmpty() ? TEXT("LootLockerServerLog") : Config->LogFileName);
+    }
+    else
+    {
+        DisableFileLogging();
+    }
 }

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
@@ -12,9 +12,7 @@
 #include "Misc/Base64.h"
 
 #if ENGINE_MAJOR_VERSION < 5
-const FString ULootLockerServerConfig::PackageName = TEXT("LootLocker");
-const FString ULootLockerServerConfig::PluginName = TEXT("LootLockerServerSDK");
-const FString ULootLockerServerConfig::ConfigFileIdentifier = TEXT("");
+const FString ULootLockerServerConfig::PreConfigFileName = TEXT("LootLockerServerPreConfig.bytes");
 bool ULootLockerServerConfig::bFileConfigChecked = false;
 TOptional<FLootLockerServerFileConfig> ULootLockerServerConfig::FileConfig;
 #endif
@@ -201,22 +199,14 @@ void ULootLockerServerConfig::LoadFileConfig()
         return;
     }
 
-    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(*PluginName);
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerServerSDK"));
     if (!Plugin.IsValid())
     {
         bFileConfigChecked = true;
         return;
     }
 
-    // Build filename: PackageName + "ServerPreConfig" + optional "-" + ConfigFileIdentifier + ".bytes"
-    FString FileName = PackageName + TEXT("ServerPreConfig");
-    if (!ConfigFileIdentifier.IsEmpty())
-    {
-        FileName += TEXT("-") + ConfigFileIdentifier;
-    }
-    FileName += TEXT(".bytes");
-
-    const FString FilePath = FPaths::Combine(Plugin->GetBaseDir(), TEXT("Config"), FileName);
+    const FString FilePath = FPaths::Combine(Plugin->GetBaseDir(), TEXT("Config"), PreConfigFileName);
 
     FString Content;
     if (!FFileHelper::LoadFileToString(Content, *FilePath))

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
@@ -11,6 +11,14 @@
 #include "Misc/AES.h"
 #include "Misc/Base64.h"
 
+#if ENGINE_MAJOR_VERSION < 5
+const FString ULootLockerServerConfig::PackageName = TEXT("LootLocker");
+const FString ULootLockerServerConfig::PluginName = TEXT("LootLockerServerSDK");
+const FString ULootLockerServerConfig::ConfigFileIdentifier = TEXT("");
+bool ULootLockerServerConfig::bFileConfigChecked = false;
+TOptional<FLootLockerServerFileConfig> ULootLockerServerConfig::FileConfig;
+#endif
+
 namespace {
     static bool bRuntimeLogLevelOverrideSet = false;
     static ELootLockerServerLogLevel RuntimeLogLevelOverride = ELootLockerServerLogLevel::Ignore;
@@ -128,6 +136,12 @@ TOptional<FLootLockerServerFileConfig> ULootLockerServerConfig::ParseFileConfigC
             return {};
         }
 
+        // FAES operates on whole blocks (AES block size is 16 bytes)
+        if (EncryptedData.Num() == 0 || (EncryptedData.Num() % 16) != 0)
+        {
+            return {};
+        }
+
         const FAES::FAESKey DecryptionKey = GetServerFileConfigDecryptionKey();
         FAES::DecryptData(EncryptedData.GetData(), EncryptedData.Num(), DecryptionKey);
 
@@ -153,8 +167,9 @@ TOptional<FLootLockerServerFileConfig> ULootLockerServerConfig::ParseFileConfigC
             }
         }
 
-        // Convert decrypted bytes to UTF-8 string
-        JsonString = FString(EncryptedData.Num(), UTF8_TO_TCHAR(reinterpret_cast<const char*>(EncryptedData.GetData())));
+        // Convert decrypted bytes to UTF-8 string (ensure null-terminated for UTF8_TO_TCHAR)
+        EncryptedData.Add(0);
+        JsonString = UTF8_TO_TCHAR(reinterpret_cast<const char*>(EncryptedData.GetData()));
 
         // Re-parse the decrypted JSON
         Reader = TJsonReaderFactory<>::Create(JsonString);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerConfig.cpp
@@ -90,7 +90,7 @@ bool ULootLockerServerConfig::IsFileConfigActive()
 {
     if (!bFileConfigChecked)
     {
-        GetDefault<ULootLockerServerConfig>()->LoadFileConfig();
+        ULootLockerServerConfig::LoadFileConfig();
     }
     return FileConfig.IsSet();
 }
@@ -231,7 +231,7 @@ void ULootLockerServerConfig::LoadFileConfig()
 
 void ULootLockerServerConfig::ApplyFileConfigIfPresent()
 {
-    if (!FileConfig.IsSet())
+    if (!IsFileConfigActive())
     {
         ULootLockerServerConfig* Default = GetMutableDefault<ULootLockerServerConfig>();
         Default->bIsFileConfigLocked = false;

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
@@ -25,6 +25,10 @@ FLootLockerServerEndPoint ULootLockerServerEndpoints::GetLeaderboardArchive = In
 FLootLockerServerEndPoint ULootLockerServerEndpoints::GetLeaderboardSchedule = InitEndpoint("leaderboards/{0}/schedule", ELootLockerServerHTTPMethod::GET);
 FLootLockerServerEndPoint ULootLockerServerEndpoints::CreateLeaderboardSchedule = InitEndpoint("leaderboards/{0}/schedule", ELootLockerServerHTTPMethod::POST);
 FLootLockerServerEndPoint ULootLockerServerEndpoints::DeleteLeaderboardSchedule = InitEndpoint("leaderboards/{0}/schedule", ELootLockerServerHTTPMethod::DELETE);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::RequestManualLeaderboardReset = InitEndpoint("leaderboards/{0}/reset", ELootLockerServerHTTPMethod::POST);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::ListManualLeaderboardResets = InitEndpoint("leaderboards/{0}/reset", ELootLockerServerHTTPMethod::GET);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::GetManualLeaderboardReset = InitEndpoint("leaderboards/{0}/reset/{1}", ELootLockerServerHTTPMethod::GET);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::CancelManualLeaderboardReset = InitEndpoint("leaderboards/{0}/reset/{1}", ELootLockerServerHTTPMethod::DELETE);
 
 // Assets
 FLootLockerServerEndPoint ULootLockerServerEndpoints::GetAssets = InitEndpoint("assets", ELootLockerServerHTTPMethod::GET);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
@@ -136,6 +136,7 @@ FLootLockerServerEndPoint ULootLockerServerEndpoints::ListCurrencies = InitEndpo
 
 // Catalogs
 FLootLockerServerEndPoint ULootLockerServerEndpoints::ListCatalogItemsByKey = InitEndpoint("catalogs/inspired-ibex/v1/key/{0}/prices", ELootLockerServerHTTPMethod::GET);
+FLootLockerServerEndPoint ULootLockerServerEndpoints::ListCatalogItemsById = InitEndpoint("catalogs/inspired-ibex/v1/catalog/items", ELootLockerServerHTTPMethod::POST);
 
 // Balances
 FLootLockerServerEndPoint ULootLockerServerEndpoints::ListBalancesInWallet = InitEndpoint("balances/wallet/{0}", ELootLockerServerHTTPMethod::GET);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerEndpoints.cpp
@@ -130,6 +130,9 @@ FLootLockerServerEndPoint ULootLockerServerEndpoints::DeleteProgressionForCharac
 // Currencies
 FLootLockerServerEndPoint ULootLockerServerEndpoints::ListCurrencies = InitEndpoint("currencies", ELootLockerServerHTTPMethod::GET);
 
+// Catalogs
+FLootLockerServerEndPoint ULootLockerServerEndpoints::ListCatalogItemsByKey = InitEndpoint("catalogs/inspired-ibex/v1/key/{0}/prices", ELootLockerServerHTTPMethod::GET);
+
 // Balances
 FLootLockerServerEndPoint ULootLockerServerEndpoints::ListBalancesInWallet = InitEndpoint("balances/wallet/{0}", ELootLockerServerHTTPMethod::GET);
 FLootLockerServerEndPoint ULootLockerServerEndpoints::GetWalletByWalletId = InitEndpoint("wallet/{0}", ELootLockerServerHTTPMethod::GET);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
@@ -138,6 +138,34 @@ FString ULootLockerServerForBlueprints::DeleteLeaderboardSchedule(const FString&
     }));
 }
 
+FString ULootLockerServerForBlueprints::RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseBP& OnCompletedRequest)
+{
+    return ULootLockerServerForCpp::RequestManualLeaderboardReset(LeaderboardKey, Request, FLootLockerServerRequestManualLeaderboardResetResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerManualLeaderboardResetResponse& Response) {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
+FString ULootLockerServerForBlueprints::ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseBP& OnCompletedRequest)
+{
+    return ULootLockerServerForCpp::ListManualLeaderboardResets(LeaderboardKey, FLootLockerServerListManualLeaderboardResetsResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerListManualLeaderboardResetsResponse& Response) {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
+FString ULootLockerServerForBlueprints::GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseBP& OnCompletedRequest)
+{
+    return ULootLockerServerForCpp::GetManualLeaderboardReset(LeaderboardKey, ResetId, FLootLockerServerGetManualLeaderboardResetResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerManualLeaderboardResetResponse& Response) {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
+FString ULootLockerServerForBlueprints::CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseBP& OnCompletedRequest)
+{
+    return ULootLockerServerForCpp::CancelManualLeaderboardReset(LeaderboardKey, ResetId, FLootLockerServerCancelManualLeaderboardResetResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerResponse& Response) {
+        OnCompletedRequest.ExecuteIfBound(Response);
+    }));
+}
+
 FString ULootLockerServerForBlueprints::ListLeaderboardArchive(const FString& LeaderboardKey, const FLootLockerServerLeaderboardArchiveResponseBP& OnCompletedRequestBP)
 {
     return ULootLockerServerForCpp::ListLeaderboardArchive(LeaderboardKey, FLootLockerServerLeaderboardArchiveResponseDelegate::CreateLambda([OnCompletedRequestBP](const FLootLockerServerLeaderboardArchiveResponse& Response) {

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
@@ -872,6 +872,13 @@ FString ULootLockerServerForBlueprints::ListCatalogItemsByKey(const FString& Cat
     }));
 }
 
+FString ULootLockerServerForBlueprints::ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseBP& OnCompletedRequestBP)
+{
+    return ULootLockerServerForCpp::ListCatalogItemsById(CatalogListingIds, IncludeMetadata, MetadataKeys, FLootLockerServerListCatalogItemsByIdResponseDelegate::CreateLambda([OnCompletedRequestBP](const FLootLockerServerListCatalogItemsByIdResponse& Response) {
+        OnCompletedRequestBP.ExecuteIfBound(Response);
+    }));
+}
+
 // Balances
 
 FString ULootLockerServerForBlueprints::ListBalancesInWallet(const FString& WalletID, const FLootLockerServerListBalancesForWalletResponseBP& OnComplete)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
@@ -836,6 +836,14 @@ FString ULootLockerServerForBlueprints::ListCurrencies(const FLootLockerServerLi
     }));
 }
 
+// Catalogs
+FString ULootLockerServerForBlueprints::ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseBP& OnCompletedRequestBP)
+{
+    return ULootLockerServerForCpp::ListCatalogItemsByKey(CatalogKey, Count, After, FLootLockerServerListCatalogPricesResponseDelegate::CreateLambda([OnCompletedRequestBP](const FLootLockerServerListCatalogPricesResponse& Response) {
+        OnCompletedRequestBP.ExecuteIfBound(Response);
+    }));
+}
+
 // Balances
 
 FString ULootLockerServerForBlueprints::ListBalancesInWallet(const FString& WalletID, const FLootLockerServerListBalancesForWalletResponseBP& OnComplete)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -652,6 +652,25 @@ FString ULootLockerServerForCpp::ListCatalogItemsByKey(const FString& CatalogKey
     return ULootLockerServerCatalogRequest::ListCatalogItemsByKey(CatalogKey, Count, After, OnCompletedRequest);
 }
 
+FString ULootLockerServerForCpp::ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnCompletedRequest)
+{
+    if (CatalogListingIds.Num() == 0)
+    {
+        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not be empty", -1);
+        OnCompletedRequest.ExecuteIfBound(ErrorResponse);
+        return {};
+    }
+
+    if (CatalogListingIds.Num() > 100)
+    {
+        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not exceed 100 items", -1);
+        OnCompletedRequest.ExecuteIfBound(ErrorResponse);
+        return {};
+    }
+
+    return ULootLockerServerCatalogRequest::ListCatalogItemsById(CatalogListingIds, IncludeMetadata, MetadataKeys, OnCompletedRequest);
+}
+
 // Balances
 
 FString ULootLockerServerForCpp::ListBalancesInWallet(const FString& WalletID, const FLootLockerServerListBalancesForWalletResponseDelegate& OnComplete)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -656,14 +656,14 @@ FString ULootLockerServerForCpp::ListCatalogItemsById(const TArray<FString>& Cat
 {
     if (CatalogListingIds.Num() == 0)
     {
-        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not be empty", -1);
+        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not be empty", LootLockerServerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT);
         OnCompletedRequest.ExecuteIfBound(ErrorResponse);
         return {};
     }
 
     if (CatalogListingIds.Num() > 100)
     {
-        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not exceed 100 items", -1);
+        FLootLockerServerListCatalogItemsByIdResponse ErrorResponse = LootLockerServerResponseFactory::Error<FLootLockerServerListCatalogItemsByIdResponse>("CatalogListingIds must not exceed 100 items", LootLockerServerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_INPUT);
         OnCompletedRequest.ExecuteIfBound(ErrorResponse);
         return {};
     }

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -626,6 +626,12 @@ FString ULootLockerServerForCpp::ListCurrencies(const FLootLockerServerListCurre
     return ULootLockerServerCurrencyRequest::ListCurrencies(OnCompletedRequest);
 }
 
+// Catalogs
+FString ULootLockerServerForCpp::ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerCatalogRequest::ListCatalogItemsByKey(CatalogKey, Count, After, OnCompletedRequest);
+}
+
 // Balances
 
 FString ULootLockerServerForCpp::ListBalancesInWallet(const FString& WalletID, const FLootLockerServerListBalancesForWalletResponseDelegate& OnComplete)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -123,6 +123,26 @@ FString ULootLockerServerForCpp::DeleteLeaderboardSchedule(const FString& Leader
     return ULootLockerServerLeaderboardRequest::DeleteLeaderboardSchedule(LeaderboardKey, OnCompletedRequest);
 }
 
+FString ULootLockerServerForCpp::RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerLeaderboardRequest::RequestManualLeaderboardReset(LeaderboardKey, Request, OnCompletedRequest);
+}
+
+FString ULootLockerServerForCpp::ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerLeaderboardRequest::ListManualLeaderboardResets(LeaderboardKey, OnCompletedRequest);
+}
+
+FString ULootLockerServerForCpp::GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerLeaderboardRequest::GetManualLeaderboardReset(LeaderboardKey, ResetId, OnCompletedRequest);
+}
+
+FString ULootLockerServerForCpp::CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+    return ULootLockerServerLeaderboardRequest::CancelManualLeaderboardReset(LeaderboardKey, ResetId, OnCompletedRequest);
+}
+
 FString ULootLockerServerForCpp::ListLeaderboardArchive(const FString& LeaderboardKey, const FLootLockerServerLeaderboardArchiveResponseDelegate& OnCompletedRequest)
 {
     return ULootLockerServerLeaderboardArchiveRequestHandler::ListLeaderboardArchive(LeaderboardKey, OnCompletedRequest);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
@@ -188,7 +188,7 @@ FString ULootLockerServerHttpClient::UploadRawFile_Internal(const TArray<uint8>&
 		if (!Response.IsValid())
 		{
 			FLootLockerServerResponse Error = LootLockerServerResponseFactory::Error<FLootLockerServerResponse>("HTTP Response was invalid", LootLockerServerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_HTTP, InRequest.RequestIdentifier);
-			LogFailedRequestInformation(Error, InRequest.RequestType, InRequest.EndPoint, FString("Data Stream"), RequestHeaders, Response->GetAllHeaders(), RequestTime);
+			LogFailedRequestInformation(Error, InRequest.RequestType, InRequest.EndPoint, FString("Data Stream"), RequestHeaders, TArray<FString>(), RequestTime);
 			InRequest.OnCompleteRequest.ExecuteIfBound(Error);
 			return;
 		}

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
@@ -8,6 +8,7 @@
 #include "Interfaces/IHttpResponse.h"
 #include "Misc/FileHelper.h"
 #include "LootLockerServerLogger.h"
+#include "LootLockerServerConfig.h"
 #include "Interfaces/IPluginManager.h"
 #include "Misc/Guid.h"
 
@@ -30,7 +31,7 @@ ULootLockerServerHttpClient::ULootLockerServerHttpClient()
 {
 	if (SDKVersion.IsEmpty())
 	{
-		const TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin("LootLockerServerSDK");
+		const TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(*ULootLockerServerConfig::PluginName);
 		if (Ptr.IsValid())
 		{
 			SDKVersion = Ptr->GetDescriptor().VersionName;
@@ -187,7 +188,7 @@ FString ULootLockerServerHttpClient::UploadRawFile_Internal(const TArray<uint8>&
 		if (!Response.IsValid())
 		{
 			FLootLockerServerResponse Error = LootLockerServerResponseFactory::Error<FLootLockerServerResponse>("HTTP Response was invalid", LootLockerServerStaticRequestErrorStatusCodes::LL_ERROR_INVALID_HTTP, InRequest.RequestIdentifier);
-			LogFailedRequestInformation(Error, InRequest.RequestType, InRequest.EndPoint, FString("Data Stream"), RequestHeaders, TArray<FString>(), RequestTime);
+			LogFailedRequestInformation(Error, InRequest.RequestType, InRequest.EndPoint, FString("Data Stream"), RequestHeaders, Response->GetAllHeaders(), RequestTime);
 			InRequest.OnCompleteRequest.ExecuteIfBound(Error);
 			return;
 		}

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerHttpClient.cpp
@@ -31,7 +31,7 @@ ULootLockerServerHttpClient::ULootLockerServerHttpClient()
 {
 	if (SDKVersion.IsEmpty())
 	{
-		const TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(*ULootLockerServerConfig::PluginName);
+		const TSharedPtr<IPlugin> Ptr = IPluginManager::Get().FindPlugin(TEXT("LootLockerServerSDK"));
 		if (Ptr.IsValid())
 		{
 			SDKVersion = Ptr->GetDescriptor().VersionName;

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
@@ -50,7 +50,7 @@ FString ULootLockerServerCatalogRequest::ListCatalogItemsById(const TArray<FStri
             OnResponseCompleted);
     }
 
-    typename ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback MetadataParser =
+    ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback MetadataParser =
         ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback::CreateLambda([OnResponseCompleted](FLootLockerServerListCatalogItemsByIdResponse& Response)
     {
         if (!Response.Success || Response.Items.Num() == 0)
@@ -83,10 +83,6 @@ FString ULootLockerServerCatalogRequest::ListCatalogItemsById(const TArray<FStri
 
             for (int j = 0; j < JsonMetadataArray.Num(); j++)
             {
-                if (j >= Entry.Metadata.Num())
-                {
-                    break;
-                }
                 TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j]->AsObject();
                 if (!JsonMetadataObject.IsValid())
                 {
@@ -112,6 +108,6 @@ FString ULootLockerServerCatalogRequest::ListCatalogItemsById(const TArray<FStri
         ULootLockerServerEndpoints::ListCatalogItemsById,
         {},
         {},
-        OnResponseCompleted,
+        FLootLockerServerListCatalogItemsByIdResponseDelegate(),
         MetadataParser);
 }

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
@@ -3,6 +3,7 @@
 #include "ServerAPI/LootLockerServerCatalogRequest.h"
 
 #include "LootLockerServerHttpClient.h"
+#include "Utils/LootLockerServerUtilities.h"
 
 ULootLockerServerCatalogRequest::ULootLockerServerCatalogRequest()
 {
@@ -26,4 +27,91 @@ FString ULootLockerServerCatalogRequest::ListCatalogItemsByKey(const FString& Ca
         { CatalogKey },
         QueryParams,
         OnResponseCompleted);
+}
+
+FString ULootLockerServerCatalogRequest::ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnResponseCompleted)
+{
+    FLootLockerServerListCatalogItemsByIdRequest Request;
+    Request.Ids = CatalogListingIds;
+
+    if (IncludeMetadata)
+    {
+        Request.Includes.Metadata.All = (MetadataKeys.Num() == 0);
+        Request.Includes.Metadata.Keys = MetadataKeys;
+    }
+
+    if (!IncludeMetadata)
+    {
+        return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListCatalogItemsByIdResponse>(
+            Request,
+            ULootLockerServerEndpoints::ListCatalogItemsById,
+            {},
+            {},
+            OnResponseCompleted);
+    }
+
+    typename ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback MetadataParser =
+        ULootLockerServerHttpClient::ResponseInspector<FLootLockerServerListCatalogItemsByIdResponse>::FLootLockerServerResponseInspectorCallback::CreateLambda([OnResponseCompleted](FLootLockerServerListCatalogItemsByIdResponse& Response)
+    {
+        if (!Response.Success || Response.Items.Num() == 0)
+        {
+            OnResponseCompleted.ExecuteIfBound(Response);
+            return;
+        }
+        TSharedPtr<FJsonObject> FullJsonObject = LootLockerServerUtilities::JsonObjectFromFString(Response.FullTextFromServer);
+        if (!FullJsonObject.IsValid())
+        {
+            OnResponseCompleted.ExecuteIfBound(Response);
+            return;
+        }
+        TArray<TSharedPtr<FJsonValue>> JsonItems = FullJsonObject->GetArrayField(TEXT("items"));
+        if (JsonItems.Num() != Response.Items.Num())
+        {
+            OnResponseCompleted.ExecuteIfBound(Response);
+            return;
+        }
+
+        for (int i = 0; i < JsonItems.Num(); i++)
+        {
+            TSharedPtr<FJsonObject> JsonItemObject = JsonItems[i]->AsObject();
+            if (!JsonItemObject.IsValid())
+            {
+                continue;
+            }
+            TArray<TSharedPtr<FJsonValue>> JsonMetadataArray = JsonItemObject->GetArrayField(TEXT("metadata"));
+            FLootLockerServerListCatalogItemsByIdEntry& Entry = Response.Items[i];
+
+            for (int j = 0; j < JsonMetadataArray.Num(); j++)
+            {
+                if (j >= Entry.Metadata.Num())
+                {
+                    break;
+                }
+                TSharedPtr<FJsonObject> JsonMetadataObject = JsonMetadataArray[j]->AsObject();
+                if (!JsonMetadataObject.IsValid())
+                {
+                    continue;
+                }
+                FString MetadataKey = JsonMetadataObject->GetStringField(TEXT("key"));
+                for (int k = 0; k < Entry.Metadata.Num(); k++)
+                {
+                    if (Entry.Metadata[k].Key.Equals(MetadataKey))
+                    {
+                        Entry.Metadata[k]._INTERNAL_SetJsonRepresentation(*JsonMetadataObject.Get());
+                        break;
+                    }
+                }
+            }
+        }
+
+        OnResponseCompleted.ExecuteIfBound(Response);
+    });
+
+    return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListCatalogItemsByIdResponse>(
+        Request,
+        ULootLockerServerEndpoints::ListCatalogItemsById,
+        {},
+        {},
+        OnResponseCompleted,
+        MetadataParser);
 }

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerCatalogRequest.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 LootLocker
+
+#include "ServerAPI/LootLockerServerCatalogRequest.h"
+
+#include "LootLockerServerHttpClient.h"
+
+ULootLockerServerCatalogRequest::ULootLockerServerCatalogRequest()
+{
+}
+
+FString ULootLockerServerCatalogRequest::ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnResponseCompleted)
+{
+    TMultiMap<FString, FString> QueryParams;
+    if (Count > 0)
+    {
+        QueryParams.Add("per_page", FString::FromInt(Count));
+    }
+    if (!After.IsEmpty())
+    {
+        QueryParams.Add("cursor", After);
+    }
+
+    return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListCatalogPricesResponse>(
+        FLootLockerServerEmptyRequest{},
+        ULootLockerServerEndpoints::ListCatalogItemsByKey,
+        { CatalogKey },
+        QueryParams,
+        OnResponseCompleted);
+}

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerLeaderboardRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerLeaderboardRequest.cpp
@@ -103,3 +103,23 @@ FString ULootLockerServerLeaderboardRequest::DeleteLeaderboardSchedule(const FSt
 {
 	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerGetLeaderboardScheduleResponse>(FLootLockerServerEmptyRequest(), ULootLockerServerEndpoints::DeleteLeaderboardSchedule, { LeaderboardKey }, {}, OnCompletedRequest);
 }
+
+FString ULootLockerServerLeaderboardRequest::RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerManualLeaderboardResetResponse>(Request, ULootLockerServerEndpoints::RequestManualLeaderboardReset, { LeaderboardKey }, {}, OnCompletedRequest);
+}
+
+FString ULootLockerServerLeaderboardRequest::ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseDelegate& OnCompletedRequest)
+{
+	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListManualLeaderboardResetsResponse>(FLootLockerServerEmptyRequest(), ULootLockerServerEndpoints::ListManualLeaderboardResets, { LeaderboardKey }, {}, OnCompletedRequest);
+}
+
+FString ULootLockerServerLeaderboardRequest::GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerManualLeaderboardResetResponse>(FLootLockerServerEmptyRequest(), ULootLockerServerEndpoints::GetManualLeaderboardReset, { LeaderboardKey, ResetId }, {}, OnCompletedRequest);
+}
+
+FString ULootLockerServerLeaderboardRequest::CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseDelegate& OnCompletedRequest)
+{
+	return ULootLockerServerHttpClient::SendRequest<FLootLockerServerResponse>(FLootLockerServerEmptyRequest(), ULootLockerServerEndpoints::CancelManualLeaderboardReset, { LeaderboardKey, ResetId }, {}, OnCompletedRequest);
+}

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
@@ -48,7 +48,7 @@ public:
 
     /**
      * Optional identifier appended to the pre-config file name, e.g. setting this to "acme" causes
-     * the SDK to look for "LootLockerServerPreConfig-acme.bytes" instead of "LootLockerServerPreConfig.bytes".
+     * the SDK to look for "<PackageName>ServerPreConfig-acme.bytes" instead of "<PackageName>ServerPreConfig.bytes".
      */
 #if ENGINE_MAJOR_VERSION >= 5
     inline static const FString ConfigFileIdentifier = TEXT("");
@@ -158,7 +158,6 @@ private:
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override
 	{
-		ApplyFileConfigIfPresent();
 		if (PropertyChangedEvent.GetPropertyName() == "LootLockerServerKey")
 		{
 			IsLegacyKey = IsLegacyAPIKey();
@@ -187,13 +186,19 @@ private:
 		IsValidGameVersion = IsSemverString(GameVersion);
 		LoadFileConfig();
 		ApplyFileConfigIfPresent();
-		if(bEnableFileLogging)
+		// File logging is already handled by ApplyFileConfigIfPresent
+		// when a file config is active. Only apply the default behavior
+		// when no file config is governing the setting.
+		if (!bIsFileConfigLocked)
 		{
-			EnableFileLogging(LogFileName.IsEmpty() ? "LootLockerServerLog" : LogFileName);
-		}
-		else
-		{
-			DisableFileLogging();
+			if(bEnableFileLogging)
+			{
+				EnableFileLogging(LogFileName.IsEmpty() ? "LootLockerServerLog" : LogFileName);
+			}
+			else
+			{
+				DisableFileLogging();
+			}
 		}
 		UObject::PostInitProperties();
 	}

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
@@ -20,6 +20,9 @@ class LOOTLOCKERSERVERSDK_API ULootLockerServerConfig : public UObject
 public:
     ULootLockerServerConfig();
 
+    /** Display name used in all editor UI. Publishers change this to rebrand the SDK. */
+    inline static const FString PackageName = TEXT("LootLocker");
+
     UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer")
     FString LootLockerServerKey = "";
     UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer")

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
@@ -33,18 +33,30 @@ public:
     static TOptional<FLootLockerServerFileConfig> ParseFileConfigContent(const FString& Content);
 
     /** Display name used in all editor UI. Publishers change this to rebrand the SDK. */
+#if ENGINE_MAJOR_VERSION >= 5
     inline static const FString PackageName = TEXT("LootLocker");
+#else
+    static const FString PackageName;
+#endif
 
     /** Name of the Unreal plugin (matches the .uplugin filename). Does not change when PackageName is rebranded. */
+#if ENGINE_MAJOR_VERSION >= 5
     inline static const FString PluginName = TEXT("LootLockerServerSDK");
+#else
+    static const FString PluginName;
+#endif
 
     /**
      * Optional identifier appended to the pre-config file name, e.g. setting this to "acme" causes
      * the SDK to look for "LootLockerServerPreConfig-acme.bytes" instead of "LootLockerServerPreConfig.bytes".
      */
+#if ENGINE_MAJOR_VERSION >= 5
     inline static const FString ConfigFileIdentifier = TEXT("");
+#else
+    static const FString ConfigFileIdentifier;
+#endif
 
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer")
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer", Meta = (EditCondition = "!bIsFileConfigLocked"))
     FString LootLockerServerKey = "";
     UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer", Meta = (EditCondition = "!bIsFileConfigLocked"))
     FString LootLockerDomainKey = "";
@@ -192,8 +204,13 @@ private:
 	bool IsValidGameVersion = true;
 	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLockerServer")
 	bool bIsFileConfigLocked = false;
+#if ENGINE_MAJOR_VERSION >= 5
 	inline static bool bFileConfigChecked = false;
 	inline static TOptional<FLootLockerServerFileConfig> FileConfig;
+#else
+	static bool bFileConfigChecked;
+	static TOptional<FLootLockerServerFileConfig> FileConfig;
+#endif
 	static void LoadFileConfig();
 	void ApplyFileConfigIfPresent();
 #if ENGINE_MAJOR_VERSION >= 5

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
@@ -41,15 +41,14 @@ public:
 #else
     static const FString PreConfigFileName;
 #endif
-
+    UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLockerServer", Meta = (EditCondition = "bIsFileConfigLocked", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "INFO:"), Transient)
+    FString FileConfigActiveNotice = "Settings are governed by the pre-configured file config shipped with the plugin and cannot be changed from the editor.";
     UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer", Meta = (EditCondition = "!bIsFileConfigLocked"))
     FString LootLockerServerKey = "";
     UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer", Meta = (EditCondition = "!bIsFileConfigLocked"))
     FString LootLockerDomainKey = "";
     UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLockerServer", Meta = (EditCondition = "IsLegacyKey", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "WARNING:"), Transient)
     FString LegacyKeyWarning = "You are using a legacy API Key, please generate a new one here: https://console.lootlocker.com/settings/api-keys";
-    UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLockerServer", Meta = (EditCondition = "bIsFileConfigLocked", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "INFO:"), Transient)
-    FString FileConfigActiveNotice = "Settings are governed by the pre-configured file config shipped with the plugin and cannot be changed from the editor.";
     UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLockerServer", Meta = (EditCondition = "!IsValidGameVersion", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "WARNING:"), Transient)
     FString InvalidGameVersionWarning = "";
     UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer", Meta = (EditCondition = "!bIsFileConfigLocked"))

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
@@ -32,28 +32,14 @@ public:
      */
     static TOptional<FLootLockerServerFileConfig> ParseFileConfigContent(const FString& Content);
 
-    /** Display name used in all editor UI. Publishers change this to rebrand the SDK. */
-#if ENGINE_MAJOR_VERSION >= 5
-    inline static const FString PackageName = TEXT("LootLocker");
-#else
-    static const FString PackageName;
-#endif
-
-    /** Name of the Unreal plugin (matches the .uplugin filename). Does not change when PackageName is rebranded. */
-#if ENGINE_MAJOR_VERSION >= 5
-    inline static const FString PluginName = TEXT("LootLockerServerSDK");
-#else
-    static const FString PluginName;
-#endif
-
     /**
-     * Optional identifier appended to the pre-config file name, e.g. setting this to "acme" causes
-     * the SDK to look for "<PackageName>ServerPreConfig-acme.bytes" instead of "<PackageName>ServerPreConfig.bytes".
+     * Filename of the pre-config file that the SDK looks for in the plugin's Config directory.
+     * Default: "LootLockerServerPreConfig.bytes"
      */
 #if ENGINE_MAJOR_VERSION >= 5
-    inline static const FString ConfigFileIdentifier = TEXT("");
+    inline static const FString PreConfigFileName = TEXT("LootLockerServerPreConfig.bytes");
 #else
-    static const FString ConfigFileIdentifier;
+    static const FString PreConfigFileName;
 #endif
 
     UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer", Meta = (EditCondition = "!bIsFileConfigLocked"))

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerConfig.h
@@ -11,6 +11,7 @@
 #include <regex>
 #endif
 #include "LootLockerServerLogger.h"
+#include "LootLockerServerFileConfig.h"
 #include "LootLockerServerConfig.generated.h"
 
 UCLASS(Config = Game, DefaultConfig, meta = (DisplayName = "LootLocker Server SDK Settings"))
@@ -18,31 +19,53 @@ class LOOTLOCKERSERVERSDK_API ULootLockerServerConfig : public UObject
 {
     GENERATED_BODY()
 public:
-    ULootLockerServerConfig();
+    /**
+     * Returns true when a pre-configured file config is active and governing settings.
+     * When true, the Project Settings panel is locked to prevent drift from the file config.
+     */
+    static bool IsFileConfigActive();
+
+    /**
+     * Parses a pre-config file's raw content (plain JSON or encrypted) into an FLootLockerServerFileConfig.
+     * Returns an empty TOptional when content is invalid or api_key is missing/empty.
+     * Exposed publicly so unit tests can call it without needing a real plugin on disk.
+     */
+    static TOptional<FLootLockerServerFileConfig> ParseFileConfigContent(const FString& Content);
 
     /** Display name used in all editor UI. Publishers change this to rebrand the SDK. */
     inline static const FString PackageName = TEXT("LootLocker");
 
+    /** Name of the Unreal plugin (matches the .uplugin filename). Does not change when PackageName is rebranded. */
+    inline static const FString PluginName = TEXT("LootLockerServerSDK");
+
+    /**
+     * Optional identifier appended to the pre-config file name, e.g. setting this to "acme" causes
+     * the SDK to look for "LootLockerServerPreConfig-acme.bytes" instead of "LootLockerServerPreConfig.bytes".
+     */
+    inline static const FString ConfigFileIdentifier = TEXT("");
+
     UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer")
     FString LootLockerServerKey = "";
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer")
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer", Meta = (EditCondition = "!bIsFileConfigLocked"))
     FString LootLockerDomainKey = "";
     UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLockerServer", Meta = (EditCondition = "IsLegacyKey", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "WARNING:"), Transient)
     FString LegacyKeyWarning = "You are using a legacy API Key, please generate a new one here: https://console.lootlocker.com/settings/api-keys";
+    UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLockerServer", Meta = (EditCondition = "bIsFileConfigLocked", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "INFO:"), Transient)
+    FString FileConfigActiveNotice = "Settings are governed by the pre-configured file config shipped with the plugin and cannot be changed from the editor.";
     UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLockerServer", Meta = (EditCondition = "!IsValidGameVersion", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "WARNING:"), Transient)
     FString InvalidGameVersionWarning = "";
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer")
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer", Meta = (EditCondition = "!bIsFileConfigLocked"))
     FString GameVersion = "";
     UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Meta = (EditCondition = "false", EditConditionHides), Category = "LootLockerServer")
     FString LootLockerVersion = "2021-06-01";
     /// Logging configuration
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer|Logging")
-    ELootLockerServerLogLevel LimitLogLevelTo = ELootLockerServerLogLevel::Display;
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer|Logging")
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer|Logging", Meta = (EditCondition = "!bIsFileConfigLocked"))
+    ELootLockerServerLogLevel LimitLogLevelTo = ELootLockerServerLogLevel::Warning;
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer|Logging", Meta = (EditCondition = "!bIsFileConfigLocked"))
     bool LogOutsideOfEditor = false;
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer|Logging")
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer|Logging", Meta = (EditCondition = "!bIsFileConfigLocked"))
     bool bEnableFileLogging = false;
-    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer|Logging")
+    UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "LootLockerServer|Logging", Meta = (EditCondition = "bEnableFileLogging && !bIsFileConfigLocked", EditConditionHides))
     FString LogFileName = TEXT("LootLockerServerLog");
     UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "LootLockerServer|Logging", Meta = (EditCondition = "bEnableFileLogging", EditConditionHides), Meta = (MultiLine = true), Meta = (DisplayName = "Actual Log File (on current device)"), Transient)
     FString LongLogFilePath = "";
@@ -123,6 +146,7 @@ private:
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override
 	{
+		ApplyFileConfigIfPresent();
 		if (PropertyChangedEvent.GetPropertyName() == "LootLockerServerKey")
 		{
 			IsLegacyKey = IsLegacyAPIKey();
@@ -149,6 +173,8 @@ private:
 	{
 		IsLegacyKey = IsLegacyAPIKey();
 		IsValidGameVersion = IsSemverString(GameVersion);
+		LoadFileConfig();
+		ApplyFileConfigIfPresent();
 		if(bEnableFileLogging)
 		{
 			EnableFileLogging(LogFileName.IsEmpty() ? "LootLockerServerLog" : LogFileName);
@@ -164,6 +190,12 @@ private:
 	bool IsLegacyKey = false;
 	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLockerServer")
 	bool IsValidGameVersion = true;
+	UPROPERTY(Config, VisibleInstanceOnly, Meta = (EditCondition = "false", EditConditionHides), Transient, Category = "LootLockerServer")
+	bool bIsFileConfigLocked = false;
+	inline static bool bFileConfigChecked = false;
+	inline static TOptional<FLootLockerServerFileConfig> FileConfig;
+	static void LoadFileConfig();
+	void ApplyFileConfigIfPresent();
 #if ENGINE_MAJOR_VERSION >= 5
 	inline static const std::regex SemverPattern = std::regex("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:\\.(0|[1-9]\\d*))?(?:\\.(0|[1-9]\\d*))?$");
 #endif

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
@@ -164,6 +164,9 @@ public:
     // Currencies
     static FLootLockerServerEndPoint ListCurrencies;
 
+    // Catalogs
+    static FLootLockerServerEndPoint ListCatalogItemsByKey;
+
     // Balances
     static FLootLockerServerEndPoint ListBalancesInWallet;
     static FLootLockerServerEndPoint GetWalletByWalletId;

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
@@ -61,6 +61,10 @@ public:
     static FLootLockerServerEndPoint GetLeaderboardSchedule;
     static FLootLockerServerEndPoint CreateLeaderboardSchedule;
     static FLootLockerServerEndPoint DeleteLeaderboardSchedule;
+    static FLootLockerServerEndPoint RequestManualLeaderboardReset;
+    static FLootLockerServerEndPoint ListManualLeaderboardResets;
+    static FLootLockerServerEndPoint GetManualLeaderboardReset;
+    static FLootLockerServerEndPoint CancelManualLeaderboardReset;
 
     // Assets
     static FLootLockerServerEndPoint GetAssets;

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerEndpoints.h
@@ -170,6 +170,7 @@ public:
 
     // Catalogs
     static FLootLockerServerEndPoint ListCatalogItemsByKey;
+    static FLootLockerServerEndPoint ListCatalogItemsById;
 
     // Balances
     static FLootLockerServerEndPoint ListBalancesInWallet;

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerFileConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerFileConfig.h
@@ -9,8 +9,8 @@
 #include "LootLockerServerFileConfig.generated.h"
 
 /**
- * Data struct for the pre-configured file config, loaded at startup from the LootLockerServerPreConfig file
- * in the plugin's Config directory. When present and containing a non-empty api_key, it overrides
+ * Data struct for the pre-configured file config, loaded at startup from the "<PackageName>ServerPreConfig[-<identifier>].bytes"
+ * file in the plugin's Config directory. When present and containing a non-empty api_key, it overrides
  * DefaultGame.ini settings and locks the editor UI to prevent drift.
  *
  * The file supports plain JSON or AES-256-ECB + PKCS7 + Base64 encrypted content. Plain JSON is

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerFileConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerFileConfig.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 LootLocker
+
+#pragma once
+
+/// @addtogroup Init
+/// @{
+
+#include "CoreMinimal.h"
+#include "LootLockerServerFileConfig.generated.h"
+
+/**
+ * Data struct for the pre-configured file config, loaded at startup from the LootLockerServerPreConfig file
+ * in the plugin's Config directory. When present and containing a non-empty api_key, it overrides
+ * DefaultGame.ini settings and locks the editor UI to prevent drift.
+ *
+ * The file supports plain JSON or AES-256-ECB + PKCS7 + Base64 encrypted content. Plain JSON is
+ * recommended during development; encrypted files should be used for distribution.
+ *
+ * Supported JSON fields:
+ *   api_key                                       (string, required — empty or missing means "inactive")
+ *   domain_key                                    (string)
+ *   game_version                                  (string, default "1.0.0.0")
+ *   log_outside_of_editor                         (bool, default false)
+ *   log_level                                     (string: "Error"|"Warning"|"Display"|"Verbose"|"VeryVerbose"|"NoLogging", default "Warning")
+ *   enable_file_logging                           (bool, default false)
+ */
+USTRUCT()
+struct LOOTLOCKERSERVERSDK_API FLootLockerServerFileConfig
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	FString api_key;
+
+	UPROPERTY()
+	FString domain_key;
+
+	UPROPERTY()
+	FString game_version = TEXT("1.0.0.0");
+
+	UPROPERTY()
+	bool log_outside_of_editor = false;
+
+	UPROPERTY()
+	FString log_level = TEXT("Warning");
+
+	UPROPERTY()
+	bool enable_file_logging = false;
+};
+
+/// @}

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerFileConfig.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerFileConfig.h
@@ -21,7 +21,7 @@
  *   domain_key                                    (string)
  *   game_version                                  (string, default "1.0.0.0")
  *   log_outside_of_editor                         (bool, default false)
- *   log_level                                     (string: "Error"|"Warning"|"Display"|"Verbose"|"VeryVerbose"|"NoLogging", default "Warning")
+ *   log_level                                     (string: "Ignore"|"Fatal"|"Error"|"Warning"|"Display"|"Log"|"Verbose"|"VeryVerbose", default "Warning")
  *   enable_file_logging                           (bool, default false)
  */
 USTRUCT()

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -2042,7 +2042,7 @@ public:
 
      @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
-    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Catalogs", meta = (AdvancedDisplay = "Count, After", Count = 0))
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Catalogs", meta = (AdvancedDisplay = "Count,After", Count = 0, After = ""))
     static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseBP& OnCompletedRequestBP);
 
     //==================================================

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -6,6 +6,7 @@
 #include "ServerAPI/LootLockerServerAssetRequest.h"
 #include "ServerAPI/LootLockerServerAuthRequest.h"
 #include "ServerAPI/LootLockerServerBalanceRequest.h"
+#include "ServerAPI/LootLockerServerCatalogRequest.h"
 #include "ServerAPI/LootLockerServerCharacterProgressionRequest.h"
 #include "ServerAPI/LootLockerServerCharacterRequest.h"
 #include "ServerAPI/LootLockerServerConnectedAccountsRequest.h"
@@ -164,6 +165,15 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListConnectedAccountsResponse
  * Blueprint response delegate for listing currencies
  */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListCurrenciesResponseBP, FLootLockerServerListCurrenciesResponse, Response);
+
+//==================================================
+// Catalog Response Delegates
+//==================================================
+
+/**
+ * Blueprint response delegate for listing catalog prices
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListCatalogPricesResponseBP, FLootLockerServerListCatalogPricesResponse, Response);
 
 //==================================================
 // Drop Table Response Delegates
@@ -2014,6 +2024,26 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Currency")
     static UPARAM(DisplayName = "RequestId") FString ListCurrencies(const FLootLockerServerListCurrenciesResponseBP& OnCompletedRequest);
+
+    //==================================================
+    // Catalogs
+    //==================================================
+
+    /**
+     List catalog items (entries with prices) for the catalog identified by the given key.
+
+     Use Count and After for cursor-based pagination. Pass After = "" and Count = 0 to get the
+     first page with the default page size.
+
+     @param CatalogKey The unique key of the catalog to list items for
+     @param Count Optional: number of items to return per page (0 = server default, typically 50)
+     @param After Optional: cursor from a previous response's Pagination.Next_cursor to get the next page; pass empty string for the first page
+     @param OnCompletedRequestBP Delegate for handling the server response
+
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Catalogs", meta = (AdvancedDisplay = "Count, After", Count = 0))
+    static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseBP& OnCompletedRequestBP);
 
     //==================================================
     // Balances

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -175,6 +175,11 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListCurrenciesResponseBP, FLo
  */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListCatalogPricesResponseBP, FLootLockerServerListCatalogPricesResponse, Response);
 
+/**
+ * Blueprint response delegate for listing catalog items by ID
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListCatalogItemsByIdResponseBP, FLootLockerServerListCatalogItemsByIdResponse, Response);
+
 //==================================================
 // Drop Table Response Delegates
 //==================================================
@@ -1216,7 +1221,7 @@ public:
      *
      * @param PlayerID The ID of the player for whom to equip the asset
      * @param AssetID The ID of the asset to equip to the specified player's loadout
-     * @param RentalOptionID The ID of the rental option of the specified asset to equip to the specified player's loadout
+     * @param RentalOptionID The ID of the specific rental option of the specified asset to equip to the specified player's loadout
      * @param OnCompletedRequest Delegate for handling the server response
      * 
      * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
@@ -2104,6 +2109,17 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Catalogs", meta = (AdvancedDisplay = "Count,After", Count = 0, After = ""))
     static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseBP& OnCompletedRequestBP);
+
+    /**
+     List catalog items by their catalog_listing_ids, with entity details and optionally metadata inlined directly.
+     @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     @param MetadataKeys Optional: Specific metadata keys to include. If empty, all metadata is returned.
+     @param OnCompletedRequestBP Delegate for handling the server response
+     @return A unique id for this request
+     */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Catalogs", meta = (AdvancedDisplay = "IncludeMetadata,MetadataKeys"))
+    static UPARAM(DisplayName = "RequestId") FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseBP& OnCompletedRequestBP);
 
     //==================================================
     // Balances

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -746,7 +746,6 @@ public:
 
     /**
     * Request a manual reset of a leaderboard
-    * The leaderboard must have allow_manual_resets enabled.
     * @param LeaderboardKey The Key of the leaderboard to reset
     * @param Request Request body specifying an optional name and optional scheduled time for the reset
     * @param OnCompletedRequest Delegate for handling the server response

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -315,6 +315,22 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerGetLeaderboardScheduleRespons
  Blueprint response delegate for leaderboard schedule deletion
  */
 DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerDeleteLeaderboardScheduleResponseBP, FLootLockerServerResponse, Response);
+/*
+ Blueprint response delegate for requesting a manual leaderboard reset
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerRequestManualLeaderboardResetResponseBP, FLootLockerServerManualLeaderboardResetResponse, Response);
+/*
+ Blueprint response delegate for listing manual leaderboard resets
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerListManualLeaderboardResetsResponseBP, FLootLockerServerListManualLeaderboardResetsResponse, Response);
+/*
+ Blueprint response delegate for getting a specific manual leaderboard reset
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerGetManualLeaderboardResetResponseBP, FLootLockerServerManualLeaderboardResetResponse, Response);
+/*
+ Blueprint response delegate for cancelling a manual leaderboard reset
+ */
+DECLARE_DYNAMIC_DELEGATE_OneParam(FLootLockerServerCancelManualLeaderboardResetResponseBP, FLootLockerServerResponse, Response);
 
 //==================================================
 // Metadata Response Delegates
@@ -727,6 +743,51 @@ public:
     */
     UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
     static UPARAM(DisplayName = "RequestId") FString DeleteLeaderboardSchedule(const FString& LeaderboardKey, const FLootLockerServerDeleteLeaderboardScheduleResponseBP& OnCompletedRequest);
+
+    /**
+    * Request a manual reset of a leaderboard
+    * The leaderboard must have allow_manual_resets enabled.
+    * @param LeaderboardKey The Key of the leaderboard to reset
+    * @param Request Request body specifying an optional name and optional scheduled time for the reset
+    * @param OnCompletedRequest Delegate for handling the server response
+    * 
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
+    static UPARAM(DisplayName = "RequestId") FString RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseBP& OnCompletedRequest);
+
+    /**
+    * List all manual reset requests for a leaderboard
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param OnCompletedRequest Delegate for handling the server response
+    * 
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
+    static UPARAM(DisplayName = "RequestId") FString ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseBP& OnCompletedRequest);
+
+    /**
+    * Get a specific manual reset request for a leaderboard
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param ResetId The ID of the manual reset to retrieve
+    * @param OnCompletedRequest Delegate for handling the server response
+    * 
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
+    static UPARAM(DisplayName = "RequestId") FString GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseBP& OnCompletedRequest);
+
+    /**
+    * Cancel a pending manual reset request for a leaderboard
+    * Only pending resets can be cancelled.
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param ResetId The ID of the manual reset to cancel
+    * @param OnCompletedRequest Delegate for handling the server response
+    * 
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Leaderboard")
+    static UPARAM(DisplayName = "RequestId") FString CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseBP& OnCompletedRequest);
 
     //==================================================
     // Leaderboard Archives

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -289,7 +289,6 @@ public:
 
     /**
     * Request a manual reset of a leaderboard
-    * The leaderboard must have allow_manual_resets enabled.
     * @param LeaderboardKey The Key of the leaderboard to reset
     * @param Request Request body specifying an optional name and optional scheduled time for the reset
     * @param OnCompletedRequest Delegate for handling the server response

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -287,6 +287,43 @@ public:
     */
     static FString DeleteLeaderboardSchedule(const FString& LeaderboardKey, const FLootLockerServerDeleteLeaderboardScheduleResponseDelegate& OnCompletedRequest);
 
+    /**
+    * Request a manual reset of a leaderboard
+    * The leaderboard must have allow_manual_resets enabled.
+    * @param LeaderboardKey The Key of the leaderboard to reset
+    * @param Request Request body specifying an optional name and optional scheduled time for the reset
+    * @param OnCompletedRequest Delegate for handling the server response
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+
+    /**
+    * List all manual reset requests for a leaderboard
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param OnCompletedRequest Delegate for handling the server response
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseDelegate& OnCompletedRequest);
+
+    /**
+    * Get a specific manual reset request for a leaderboard
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param ResetId The ID of the manual reset to retrieve
+    * @param OnCompletedRequest Delegate for handling the server response
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+
+    /**
+    * Cancel a pending manual reset request for a leaderboard
+    * Only pending resets can be cancelled.
+    * @param LeaderboardKey The Key of the leaderboard
+    * @param ResetId The ID of the manual reset to cancel
+    * @param OnCompletedRequest Delegate for handling the server response
+    * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+    */
+    static FString CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+
     /// @}
 
     //==================================================

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -7,6 +7,7 @@
 #include "ServerAPI/LootLockerServerAssetRequest.h"
 #include "ServerAPI/LootLockerServerAuthRequest.h"
 #include "ServerAPI/LootLockerServerBalanceRequest.h"
+#include "ServerAPI/LootLockerServerCatalogRequest.h"
 #include "ServerAPI/LootLockerServerCharacterProgressionRequest.h"
 #include "ServerAPI/LootLockerServerCharacterRequest.h"
 #include "ServerAPI/LootLockerServerConnectedAccountsRequest.h"
@@ -1432,6 +1433,29 @@ public:
      * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
     static FString ListCurrencies(const FLootLockerServerListCurrenciesResponseDelegate& OnCompletedRequest);
+
+    /// @}
+
+    //==================================================
+    // Catalogs
+    //==================================================
+    /// @addtogroup Catalogs
+    /// @{
+
+    /**
+     List catalog items (entries with prices) for the catalog identified by the given key.
+
+     Use Count and After for cursor-based pagination. Pass After = "" and Count = 0 to get the
+     first page with the default page size.
+
+     @param CatalogKey The unique key of the catalog to list items for
+     @param Count Optional: number of items to return per page (0 = server default, typically 50)
+     @param After Optional: cursor from a previous response's Pagination.Next_cursor to get the next page; pass empty string for the first page
+     @param OnCompletedRequest Delegate for handling the server response
+
+     @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     */
+    static FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnCompletedRequest);
 
     /// @}
 

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -1493,6 +1493,16 @@ public:
      */
     static FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnCompletedRequest);
 
+    /**
+     List catalog items by their catalog_listing_ids, with entity details and optionally metadata inlined directly.
+     @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     @param MetadataKeys Optional: Specific metadata keys to include. If empty, all metadata is returned.
+     @param OnCompletedRequest Delegate for handling the server response
+     @return A unique id for this request
+     */
+    static FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnCompletedRequest);
+
     /// @}
 
     //==================================================

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
@@ -1,0 +1,592 @@
+// Copyright (c) 2021 LootLocker
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "LootLockerServerResponse.h"
+#include "LootLockerServerCatalogRequest.generated.h"
+
+//==================================================
+// Data Type Definitions
+//==================================================
+
+/**
+ * Possible entity kinds that catalog entries can have
+ */
+UENUM(BlueprintType, Category = "LootLockerServer")
+enum class ELootLockerServerCatalogEntryEntityKind : uint8
+{
+    Asset = 0,
+    Currency = 1,
+    Progression_Points = 2,
+    Progression_Reset = 3,
+    Group = 4,
+};
+
+/**
+ * Represents a catalog with its name, unique key, identifier, and creation timestamp.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalog
+{
+    GENERATED_BODY()
+    /**
+     * The time when this catalog was created
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Created_at;
+    /**
+     * The name of the catalog
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name;
+    /**
+     * The unique identifying key of the catalog
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Key;
+    /**
+     * The id of the catalog
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    /**
+     * The time when this catalog was deleted, should normally be empty
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Deleted_at;
+};
+
+/**
+ * Represents a price for a catalog entry in a specific currency, including the numeric amount,
+ * display-friendly string, and unique price identifier.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogEntryPrice
+{
+    GENERATED_BODY()
+    /**
+     * The amount (cost) set for this price
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Amount = 0;
+    /**
+     * A prettified version of the amount to use for display
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Display_amount;
+    /**
+     * The short code for the currency this price is in
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Currency_code;
+    /**
+     * The name of the currency this price is in
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Currency_name;
+    /**
+     * The unique id of this price
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Price_id;
+    /**
+     * The unique id of the currency this price is in
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Currency_id;
+};
+
+/**
+ * Holds the Apple App Store product identifier for a catalog entry.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogAppleAppStoreListing
+{
+    GENERATED_BODY()
+    /**
+     * The id of the product in Apple App Store
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Product_id;
+};
+
+/**
+ * Holds the Google Play Store product identifier for a catalog entry.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogGooglePlayStoreListing
+{
+    GENERATED_BODY()
+    /**
+     * The id of the product in Google Play Store
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Product_id;
+};
+
+/**
+ * Represents a single price point for a Steam Store listing.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogSteamStoreListingPrice
+{
+    GENERATED_BODY()
+    /**
+     * Currency code of the currency to be used for purchasing this listing
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Currency;
+    /**
+     * Amount of the base value of the specified currency that this listing costs to purchase
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Amount = 0;
+};
+
+/**
+ * Holds the Steam Store listing for a catalog entry.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogSteamStoreListing
+{
+    GENERATED_BODY()
+    /**
+     * Description of this listing
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Description;
+    /**
+     * List of prices for this listing
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerCatalogSteamStoreListingPrice> Prices;
+};
+
+/**
+ * Holds the Stripe payment details for a catalog entry.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogStripeStoreListing
+{
+    GENERATED_BODY()
+    /**
+     * The currency to use for the purchase
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Currency;
+    /**
+     * The amount to charge in the smallest unit of the currency (e.g. cents for USD)
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Amount = 0;
+};
+
+/**
+ * Holds the Epic Games Store audience item identifier associated with a catalog entry listing.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogEpicGamesStoreListing
+{
+    GENERATED_BODY()
+    /**
+     * The Epic Games audience item id associated with this listing
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Audience_item_id;
+};
+
+/**
+ * Holds the PlayStation Store entitlement label associated with a catalog entry listing.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogPlaystationStoreListing
+{
+    GENERATED_BODY()
+    /**
+     * The Playstation entitlement label associated with this listing
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Entitlement_label;
+};
+
+/**
+ * Aggregates the platform-specific store listing information configured for a catalog entry.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogEntryListings
+{
+    GENERATED_BODY()
+    /**
+     * The listing information (if configured) for Apple App Store
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogAppleAppStoreListing Apple_app_store;
+    /**
+     * The listing information (if configured) for Google Play Store
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogGooglePlayStoreListing Google_play_store;
+    /**
+     * The listing information (if configured) for Steam Store
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogSteamStoreListing Steam_store;
+    /**
+     * The listing information (if configured) for Stripe
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogStripeStoreListing Stripe_store;
+    /**
+     * The listing information (if configured) for Epic Games Store
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogEpicGamesStoreListing Epic_games_store;
+    /**
+     * The listing information (if configured) for PlayStation Store
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogPlaystationStoreListing Playstation_store;
+};
+
+/**
+ * Represents a single item in a catalog, including its entity type, prices, store listings,
+ * purchasability flag, non-refundable flag, and unique catalog listing identifier.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogEntry
+{
+    GENERATED_BODY()
+    /**
+     * The time when this catalog entry was created
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Created_at;
+    /**
+     * The kind of entity that this entry is. This signifies in which lookup structure to find
+     * the details of this entry by using the Catalog_listing_id.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    ELootLockerServerCatalogEntryEntityKind Entity_kind = ELootLockerServerCatalogEntryEntityKind::Asset;
+    /**
+     * All the listings configured for this catalog entry
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogEntryListings Listings;
+    /**
+     * The name of this entity
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Entity_name;
+    /**
+     * A list of prices for this catalog entry
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerCatalogEntryPrice> Prices;
+    /**
+     * The unique id of the entity that this entry refers to.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Entity_id;
+    /**
+     * A unique listing id for this entry in this catalog, grouping the entity and the prices.
+     * This is the key you use to look up details about the entity in the structure signified by Entity_kind.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+    /**
+     * Whether this entry is currently purchasable
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool Purchasable = false;
+    /**
+     * Whether this entry is refundable. If false, purchases of this entry cannot be refunded.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool Non_refundable = false;
+};
+
+/**
+ * Holds detail information about an asset catalog entity, including its name, ULID, legacy
+ * numeric id, thumbnail, and optional variation or rental option identifiers.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogAssetDetails
+{
+    GENERATED_BODY()
+    /**
+     * The name of this asset
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name;
+    /**
+     * The id of the specific variation of this asset that this refers to.
+     * Asset Variations is a deprecated feature, this is added for backward compatibility only.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Variation_id;
+    /**
+     * The id of the specific rental option of this asset that this refers to.
+     * Asset Rental Options is a deprecated feature, this is added for backward compatibility only.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Rental_option_id;
+    /**
+     * The legacy numeric id of this asset
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Legacy_id = 0;
+    /**
+     * The unique identifying ulid of this asset
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    /**
+     * The thumbnail for this asset
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Thumbnail;
+    /**
+     * The catalog listing id for this asset detail
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+};
+
+/**
+ * Holds details about a progression-points catalog entity.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogProgressionPointDetails
+{
+    GENERATED_BODY()
+    /**
+     * The unique key of the progression that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Key;
+    /**
+     * The name of the progression that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name;
+    /**
+     * The amount of points to be added to the progression in question
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Amount = 0;
+    /**
+     * The unique id of the progression that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    /**
+     * The catalog listing id for this progression point detail
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+};
+
+/**
+ * Holds details about a progression-reset catalog entity.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogProgressionResetDetails
+{
+    GENERATED_BODY()
+    /**
+     * The unique key of the progression that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Key;
+    /**
+     * The name of the progression that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name;
+    /**
+     * The unique id of the progression that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    /**
+     * The catalog listing id for this progression reset detail
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+};
+
+/**
+ * Holds details about a currency catalog entity.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogCurrencyDetails
+{
+    GENERATED_BODY()
+    /**
+     * The name of the currency that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name;
+    /**
+     * The unique short code of the currency that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Code;
+    /**
+     * The amount of this currency to be awarded
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Amount;
+    /**
+     * The unique id of the currency that this refers to
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    /**
+     * The catalog listing id for this currency detail
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+};
+
+/**
+ * Holds details about a catalog group entity.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogGroupDetails
+{
+    GENERATED_BODY()
+    /**
+     * The name of the Group
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name;
+    /**
+     * The description of the Group
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Description;
+    /**
+     * The unique id of the Group
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    /**
+     * The catalog listing id for this group detail
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+};
+
+/**
+ * Cursor-based pagination information for a catalog listing response.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogPagination
+{
+    GENERATED_BODY()
+    /**
+     * The total number of items in the catalog
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int64 Total = 0;
+    /**
+     * The cursor to use to get the next page of results. Empty string means there are no more pages.
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Next_cursor;
+};
+
+//==================================================
+// Request Definitions
+//==================================================
+
+// N/A
+
+//==================================================
+// Response Definitions
+//==================================================
+
+/**
+ * Response containing catalog entries with entity-typed detail arrays and cursor-based pagination.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogPricesResponse : public FLootLockerServerResponse
+{
+    GENERATED_BODY()
+    /**
+     * Information about the catalog
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalog Catalog;
+    /**
+     * The catalog entries (items with prices)
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerCatalogEntry> Entries;
+    /**
+     * Details for catalog entries with entity_kind == Asset
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerCatalogAssetDetails> Assets_details;
+    /**
+     * Details for catalog entries with entity_kind == Progression_Points
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerCatalogProgressionPointDetails> Progression_points_details;
+    /**
+     * Details for catalog entries with entity_kind == Progression_Reset
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerCatalogProgressionResetDetails> Progression_resets_details;
+    /**
+     * Details for catalog entries with entity_kind == Currency
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerCatalogCurrencyDetails> Currency_details;
+    /**
+     * Details for catalog entries with entity_kind == Group
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerCatalogGroupDetails> Group_details;
+    /**
+     * Pagination information — use Next_cursor to fetch subsequent pages
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogPagination Pagination;
+};
+
+//==================================================
+// C++ Delegate Definitions
+//==================================================
+
+/**
+ * C++ response delegate for listing catalog prices
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerListCatalogPricesResponseDelegate, FLootLockerServerListCatalogPricesResponse);
+
+//==================================================
+// API Class Definition
+//==================================================
+
+UCLASS()
+class LOOTLOCKERSERVERSDK_API ULootLockerServerCatalogRequest : public UObject
+{
+    GENERATED_BODY()
+public:
+    ULootLockerServerCatalogRequest();
+
+    /**
+     * List catalog items (entries with prices) for the catalog identified by the given key.
+     *
+     * Use Count and After for cursor-based pagination. Pass After = "" and Count = 0 to get the
+     * first page with the default page size.
+     *
+     * @param CatalogKey The unique key of the catalog to list items for
+     * @param Count Optional: number of items to return per page (0 = server default)
+     * @param After Optional: cursor from a previous response's Pagination.Next_cursor to get the next page
+     * @param OnResponseCompleted Delegate for handling the response
+     */
+    static FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnResponseCompleted);
+};

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
@@ -718,5 +718,13 @@ public:
      * @param OnResponseCompleted Delegate for handling the response
      */
     static FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnResponseCompleted);
+    /**
+     * List catalog items by their catalog_listing_ids, with entity details and optionally metadata inlined directly.
+     *
+     * @param CatalogListingIds Array of catalog_listing_id strings to look up (max 100)
+     * @param IncludeMetadata If true, includes metadata for each entry, filtered by MetadataKeys if provided
+     * @param MetadataKeys Optional: specific metadata keys to include. If empty, all metadata is returned.
+     * @param OnResponseCompleted Delegate for handling the response
+     */
     static FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnResponseCompleted);
 };

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerCatalogRequest.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "LootLockerServerResponse.h"
+#include "ServerAPI/LootLockerServerMetadataRequest.h"
 #include "LootLockerServerCatalogRequest.generated.h"
 
 //==================================================
@@ -498,11 +499,122 @@ struct FLootLockerServerCatalogPagination
     FString Next_cursor;
 };
 
+/**
+ * A group association with the entity detail inlined directly.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerInlinedGroupAssociation
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    ELootLockerServerCatalogEntryEntityKind Kind = ELootLockerServerCatalogEntryEntityKind::Asset;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogAssetDetails Asset_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogCurrencyDetails Currency_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogProgressionPointDetails Progression_point_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogProgressionResetDetails Progression_reset_detail;
+};
+
+/**
+ * Group detail used by the ListCatalogItemsById endpoint, with association details inlined.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerInlinedGroupDetailsWithAssociations
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Description;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Catalog_listing_id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerInlinedGroupAssociation> Associations;
+};
+
+/**
+ * A catalog entry with entity details inlined directly.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogItemsByIdEntry : public FLootLockerServerCatalogEntry
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogAssetDetails Asset_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogCurrencyDetails Currency_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogProgressionPointDetails Progression_point_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogProgressionResetDetails Progression_reset_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerInlinedGroupDetailsWithAssociations Group_detail;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerMetadataEntry> Metadata;
+};
+
+/**
+ * Describes why a specific catalog_listing_id could not be resolved.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogItemsByIdError
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Id;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Reason;
+};
+
+/**
+ * Metadata include configuration for catalog items lookup.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogMetadataInclude
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool All = false;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FString> Keys;
+};
+
+/**
+ * Optional includes configuration for catalog items lookup.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerCatalogItemsIncludes
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogMetadataInclude Metadata;
+};
+
 //==================================================
 // Request Definitions
 //==================================================
 
-// N/A
+/**
+ * Request body for looking up catalog items by their catalog_listing_ids.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogItemsByIdRequest
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FString> Ids;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FLootLockerServerCatalogItemsIncludes Includes;
+};
 
 //==================================================
 // Response Definitions
@@ -557,6 +669,19 @@ struct FLootLockerServerListCatalogPricesResponse : public FLootLockerServerResp
     FLootLockerServerCatalogPagination Pagination;
 };
 
+/**
+ * Response for the ListCatalogItemsById endpoint.
+ */
+USTRUCT(BlueprintType, Category = "LootLockerServer")
+struct FLootLockerServerListCatalogItemsByIdResponse : public FLootLockerServerResponse
+{
+    GENERATED_BODY()
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerListCatalogItemsByIdEntry> Items;
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerListCatalogItemsByIdError> Errors;
+};
+
 //==================================================
 // C++ Delegate Definitions
 //==================================================
@@ -565,6 +690,10 @@ struct FLootLockerServerListCatalogPricesResponse : public FLootLockerServerResp
  * C++ response delegate for listing catalog prices
  */
 DECLARE_DELEGATE_OneParam(FLootLockerServerListCatalogPricesResponseDelegate, FLootLockerServerListCatalogPricesResponse);
+/**
+ * C++ response delegate for listing catalog items by ID
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerListCatalogItemsByIdResponseDelegate, FLootLockerServerListCatalogItemsByIdResponse);
 
 //==================================================
 // API Class Definition
@@ -589,4 +718,5 @@ public:
      * @param OnResponseCompleted Delegate for handling the response
      */
     static FString ListCatalogItemsByKey(const FString& CatalogKey, int Count, const FString& After, const FLootLockerServerListCatalogPricesResponseDelegate& OnResponseCompleted);
+    static FString ListCatalogItemsById(const TArray<FString>& CatalogListingIds, bool IncludeMetadata, const TArray<FString>& MetadataKeys, const FLootLockerServerListCatalogItemsByIdResponseDelegate& OnResponseCompleted);
 };

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
@@ -439,11 +439,6 @@ struct FLootLockerServerLeaderboard
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Has_metadata = false;
     /**
-    Whether manual resets can be requested for this leaderboard via the server API
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    bool Allow_manual_resets = false;
-    /**
     The creation time of this leaderboard
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
@@ -556,11 +551,6 @@ public:
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Overwrite_score_on_submit = false;
-    /**
-    Allow manual resets to be requested for this leaderboard via the server API
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    bool Allow_manual_resets = false;
 };
 
 USTRUCT(BlueprintType)
@@ -686,11 +676,6 @@ struct FLootLockerServerLeaderboardBaseResponse : public FLootLockerServerRespon
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Has_metadata = false;
-    /**
-    Whether manual resets can be requested for this leaderboard via the server API
-     */
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
-    bool Allow_manual_resets = false;
     /**
     The creation time of this leaderboard
      */

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerLeaderboardRequest.h
@@ -439,6 +439,11 @@ struct FLootLockerServerLeaderboard
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Has_metadata = false;
     /**
+    Whether manual resets can be requested for this leaderboard via the server API
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool Allow_manual_resets = false;
+    /**
     The creation time of this leaderboard
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
@@ -551,6 +556,11 @@ public:
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Overwrite_score_on_submit = false;
+    /**
+    Allow manual resets to be requested for this leaderboard via the server API
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool Allow_manual_resets = false;
 };
 
 USTRUCT(BlueprintType)
@@ -677,6 +687,11 @@ struct FLootLockerServerLeaderboardBaseResponse : public FLootLockerServerRespon
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
     bool Has_metadata = false;
     /**
+    Whether manual resets can be requested for this leaderboard via the server API
+     */
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    bool Allow_manual_resets = false;
+    /**
     The creation time of this leaderboard
      */
     UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
@@ -785,6 +800,141 @@ struct FLootLockerServerGetLeaderboardScheduleResponse : public FLootLockerServe
     TArray<FString> schedule;
 };
 
+USTRUCT(BlueprintType)
+/**
+ * A manual leaderboard reset request that has been submitted to the server.
+ **/
+struct FLootLockerServerManualLeaderboardReset
+{
+    GENERATED_BODY()
+    /**
+     * The unique ID of this manual reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Id = 0;
+    /**
+     * The ID of the leaderboard this reset belongs to.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Leaderboard_id = 0;
+    /**
+     * The ID of the game this reset belongs to.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Game_id = 0;
+    /**
+     * Optional human-readable name for this reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name = "";
+    /**
+     * The current processing status of this reset (pending, processing, completed, failed).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Status = "";
+    /**
+     * The UTC time at which this reset is scheduled to be processed (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Scheduled_for = "";
+    /**
+     * The UTC time at which this reset was requested (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Requested_at = "";
+    /**
+     * The UTC time at which this reset was processed (ISO 8601). Empty if not yet processed.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Processed_at = "";
+    /**
+     * Error message if the reset failed. Empty if not failed.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Error_message = "";
+};
+
+USTRUCT(BlueprintType)
+/**
+ * Request body for creating a manual leaderboard reset.
+ **/
+struct FLootLockerServerCreateManualLeaderboardResetRequest
+{
+    GENERATED_BODY()
+    /**
+     * Optional human-readable name to identify this reset.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name = "";
+    /**
+     * Optional UTC time at which to schedule this reset (ISO 8601). Defaults to immediate processing.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Scheduled_for = "";
+};
+
+USTRUCT(BlueprintType)
+struct FLootLockerServerManualLeaderboardResetResponse : public FLootLockerServerResponse
+{
+    GENERATED_BODY()
+    /**
+     * The unique ID of this manual reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Id = 0;
+    /**
+     * The ID of the leaderboard this reset belongs to.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Leaderboard_id = 0;
+    /**
+     * The ID of the game this reset belongs to.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    int Game_id = 0;
+    /**
+     * Optional human-readable name for this reset request.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Name = "";
+    /**
+     * The current processing status of this reset (pending, processing, completed, failed).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Status = "";
+    /**
+     * The UTC time at which this reset is scheduled to be processed (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Scheduled_for = "";
+    /**
+     * The UTC time at which this reset was requested (ISO 8601).
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Requested_at = "";
+    /**
+     * The UTC time at which this reset was processed (ISO 8601). Empty if not yet processed.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Processed_at = "";
+    /**
+     * Error message if the reset failed. Empty if not failed.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    FString Error_message = "";
+};
+
+USTRUCT(BlueprintType)
+struct FLootLockerServerListManualLeaderboardResetsResponse : public FLootLockerServerResponse
+{
+    GENERATED_BODY()
+    /**
+     * List of manual reset requests for this leaderboard.
+     **/
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "LootLockerServer")
+    TArray<FLootLockerServerManualLeaderboardReset> Items;
+};
+
 USTRUCT()
 struct FLootLockerServerListLeaderboardsResponse : public FLootLockerServerResponse
 {
@@ -851,6 +1001,22 @@ DECLARE_DELEGATE_OneParam(FLootLockerServerGetLeaderboardScheduleResponseDelegat
  C++ response delegate for leaderboard schedule deletion
  */
 DECLARE_DELEGATE_OneParam(FLootLockerServerDeleteLeaderboardScheduleResponseDelegate, FLootLockerServerResponse);
+/*
+ C++ response delegate for requesting a manual leaderboard reset
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerRequestManualLeaderboardResetResponseDelegate, FLootLockerServerManualLeaderboardResetResponse);
+/*
+ C++ response delegate for listing manual leaderboard resets
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerListManualLeaderboardResetsResponseDelegate, FLootLockerServerListManualLeaderboardResetsResponse);
+/*
+ C++ response delegate for getting a specific manual leaderboard reset
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerGetManualLeaderboardResetResponseDelegate, FLootLockerServerManualLeaderboardResetResponse);
+/*
+ C++ response delegate for cancelling a manual leaderboard reset
+ */
+DECLARE_DELEGATE_OneParam(FLootLockerServerCancelManualLeaderboardResetResponseDelegate, FLootLockerServerResponse);
 
 //==================================================
 // Interface Definition
@@ -876,6 +1042,11 @@ public:
     static FString GetLeaderboardSchedule(const FString& LeaderboardKey, const FLootLockerServerGetLeaderboardScheduleResponseDelegate& OnCompletedRequest);
     static FString CreateLeaderboardSchedule(const FString& LeaderboardKey, const FString& CronExpression, const FLootLockerServerGetLeaderboardScheduleResponseDelegate& OnCompletedRequest);
     static FString DeleteLeaderboardSchedule(const FString& LeaderboardKey, const FLootLockerServerDeleteLeaderboardScheduleResponseDelegate& OnCompletedRequest);
+
+    static FString RequestManualLeaderboardReset(const FString& LeaderboardKey, const FLootLockerServerCreateManualLeaderboardResetRequest& Request, const FLootLockerServerRequestManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+    static FString ListManualLeaderboardResets(const FString& LeaderboardKey, const FLootLockerServerListManualLeaderboardResetsResponseDelegate& OnCompletedRequest);
+    static FString GetManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerGetManualLeaderboardResetResponseDelegate& OnCompletedRequest);
+    static FString CancelManualLeaderboardReset(const FString& LeaderboardKey, const FString& ResetId, const FLootLockerServerCancelManualLeaderboardResetResponseDelegate& OnCompletedRequest);
 
 public:
     ULootLockerServerLeaderboardRequest();

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Tests/LootLockerServerFileConfigTest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Tests/LootLockerServerFileConfigTest.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 LootLocker
+
+#include "CoreMinimal.h"
+#include "LootLockerServerConfig.h"
+#include "Misc/AutomationTest.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FLootLockerServerFileConfigTest, "LootLocker.Server.FileConfig",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FLootLockerServerFileConfigTest::RunTest(const FString& Parameters)
+{
+    // Empty content → no config
+    {
+        const auto Result = ULootLockerServerConfig::ParseFileConfigContent(TEXT(""));
+        TestFalse(TEXT("Empty content is inactive"), Result.IsSet());
+    }
+
+    // Plain JSON without api_key → inactive
+    {
+        const auto Result = ULootLockerServerConfig::ParseFileConfigContent(TEXT("{}"));
+        TestFalse(TEXT("Missing api_key is inactive"), Result.IsSet());
+    }
+
+    // Plain JSON with api_key → active
+    {
+        const auto Result = ULootLockerServerConfig::ParseFileConfigContent(
+            TEXT("{\"api_key\": \"test_prod_abc123\", \"game_version\": \"2.0.0\"}"));
+        TestTrue(TEXT("Valid config is active"), Result.IsSet());
+        TestEqual(TEXT("api_key"), Result.GetValue().api_key, TEXT("test_prod_abc123"));
+        TestEqual(TEXT("game_version"), Result.GetValue().game_version, TEXT("2.0.0"));
+    }
+
+    // Encrypted content → active
+    {
+        // This is a pre-generated encrypted test payload
+        const FString Encrypted = TEXT("t+9Vz7uXf2jKpL1mQnR5wA==");
+        // Invalid Base64 / wrong key will fail gracefully
+        const auto Result = ULootLockerServerConfig::ParseFileConfigContent(Encrypted);
+        // The decryption will fail, but we just verify no crash
+        TestFalse(TEXT("Invalid encrypted content is inactive"), Result.IsSet());
+    }
+
+    return true;
+}
+
+#endif

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Tests/LootLockerServerFileConfigTest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Tests/LootLockerServerFileConfigTest.cpp
@@ -6,7 +6,7 @@
 
 #if WITH_DEV_AUTOMATION_TESTS
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FLootLockerServerFileConfigTest, "LootLocker.Server.FileConfig",
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FLootLockerServerFileConfigTest, "LootLockerServer.Config.FileConfig",
     EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 
 bool FLootLockerServerFileConfigTest::RunTest(const FString& Parameters)
@@ -32,11 +32,11 @@ bool FLootLockerServerFileConfigTest::RunTest(const FString& Parameters)
         TestEqual(TEXT("game_version"), Result.GetValue().game_version, TEXT("2.0.0"));
     }
 
-    // Encrypted content → active
+    // Encrypted content (wrong key/invalid payload) → inactive (verify graceful failure)
     {
         // This is a pre-generated encrypted test payload
         const FString Encrypted = TEXT("t+9Vz7uXf2jKpL1mQnR5wA==");
-        // Invalid Base64 / wrong key will fail gracefully
+        // Wrong key / invalid ciphertext should fail gracefully
         const auto Result = ULootLockerServerConfig::ParseFileConfigContent(Encrypted);
         // The decryption will fail, but we just verify no crash
         TestFalse(TEXT("Invalid encrypted content is inactive"), Result.IsSet());

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/LootLockerServerSDKEditor.Build.cs
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/LootLockerServerSDKEditor.Build.cs
@@ -8,7 +8,7 @@ public class LootLockerServerSDKEditor : ModuleRules
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PrivateDependencyModuleNames.AddRange(new string[] {
-            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerServerSDK", "InputCore"
+            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerServerSDK", "InputCore", "Json", "JsonUtilities"
         });
 
         PublicDependencyModuleNames.AddRange(new string[] {

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/LootLockerServerSDKEditor.Build.cs
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/LootLockerServerSDKEditor.Build.cs
@@ -8,7 +8,7 @@ public class LootLockerServerSDKEditor : ModuleRules
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
         PrivateDependencyModuleNames.AddRange(new string[] {
-            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerServerSDK", "InputCore", "Json", "JsonUtilities"
+            "Core", "CoreUObject", "Engine", "Slate", "SlateCore", "UnrealEd", "ToolMenus", "LootLockerServerSDK", "InputCore", "Json"
         });
 
         PublicDependencyModuleNames.AddRange(new string[] {

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerSDKEditor.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerSDKEditor.cpp
@@ -7,6 +7,7 @@
 #include "Widgets/Layout/SBox.h"
 #include "LootLockerServerLogViewerWidget.h"
 #include "LootLockerServerUpdateChecker.h"
+#include "LootLockerServerConfig.h"
 #include "Editor.h"
 #include "Editor/EditorEngine.h"
 #include "Framework/Application/SlateApplication.h"
@@ -33,7 +34,7 @@ public:
                         SNew(SLootLockerServerLogViewerWidget)
                     ];
             })
-        ).SetDisplayName(FText::FromString("LootLocker Server Log Viewer"))
+        ).SetDisplayName(FText::FromString(ULootLockerServerConfig::PackageName + TEXT(" Server Log Viewer")))
          .SetMenuType(ETabSpawnerMenuType::Enabled);
 
         UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateLambda([]
@@ -41,11 +42,12 @@ public:
             UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Tools");
             if (Menu)
             {
-                FToolMenuSection& Section = Menu->AddSection("LootLocker Tools", FText::FromString("LootLocker Tools"));
+                const FString LLSectionName = ULootLockerServerConfig::PackageName + TEXT(" Tools");
+                FToolMenuSection& Section = Menu->AddSection(*LLSectionName, FText::FromString(LLSectionName));
                 Section.AddMenuEntry(
                     "LootLockerServerLogViewerMenuEntry",
-                    FText::FromString("LootLocker Server Log Viewer"),
-                    FText::FromString("Open the LootLocker Server Log Viewer window."),
+                    FText::FromString(ULootLockerServerConfig::PackageName + TEXT(" Server Log Viewer")),
+                    FText::FromString(FString::Printf(TEXT("Open the %s Server Log Viewer window."), *ULootLockerServerConfig::PackageName)),
                     FSlateIcon(),
                     FUIAction(FExecuteAction::CreateLambda([]
                     {
@@ -55,7 +57,7 @@ public:
                 Section.AddMenuEntry(
                     "LootLockerServerCheckForUpdates",
                     FText::FromString("Check for Updates"),
-                    FText::FromString("Check if a newer version of the LootLocker Server SDK is available."),
+                    FText::FromString(FString::Printf(TEXT("Check if a newer version of the %s Server SDK is available."), *ULootLockerServerConfig::PackageName)),
                     FSlateIcon(),
                     FUIAction(FExecuteAction::CreateStatic(&FLootLockerServerUpdateChecker::ManualCheck))
                 );

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerSDKEditor.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerSDKEditor.cpp
@@ -7,7 +7,6 @@
 #include "Widgets/Layout/SBox.h"
 #include "LootLockerServerLogViewerWidget.h"
 #include "LootLockerServerUpdateChecker.h"
-#include "LootLockerServerConfig.h"
 #include "Editor.h"
 #include "Editor/EditorEngine.h"
 #include "Framework/Application/SlateApplication.h"
@@ -34,7 +33,7 @@ public:
                         SNew(SLootLockerServerLogViewerWidget)
                     ];
             })
-        ).SetDisplayName(FText::FromString(ULootLockerServerConfig::PackageName + TEXT(" Server Log Viewer")))
+        ).SetDisplayName(FText::FromString(TEXT("LootLocker Server Log Viewer")))
          .SetMenuType(ETabSpawnerMenuType::Enabled);
 
         UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateLambda([]
@@ -42,12 +41,11 @@ public:
             UToolMenu* Menu = UToolMenus::Get()->ExtendMenu("LevelEditor.MainMenu.Tools");
             if (Menu)
             {
-                const FString LLSectionName = ULootLockerServerConfig::PackageName + TEXT(" Tools");
-                FToolMenuSection& Section = Menu->AddSection(*LLSectionName, FText::FromString(LLSectionName));
+                FToolMenuSection& Section = Menu->AddSection("LootLocker Tools", FText::FromString(TEXT("LootLocker Tools")));
                 Section.AddMenuEntry(
                     "LootLockerServerLogViewerMenuEntry",
-                    FText::FromString(ULootLockerServerConfig::PackageName + TEXT(" Server Log Viewer")),
-                    FText::FromString(FString::Printf(TEXT("Open the %s Server Log Viewer window."), *ULootLockerServerConfig::PackageName)),
+                    FText::FromString(TEXT("LootLocker Server Log Viewer")),
+                    FText::FromString(TEXT("Open the LootLocker Server Log Viewer window.")),
                     FSlateIcon(),
                     FUIAction(FExecuteAction::CreateLambda([]
                     {
@@ -57,7 +55,7 @@ public:
                 Section.AddMenuEntry(
                     "LootLockerServerCheckForUpdates",
                     FText::FromString("Check for Updates"),
-                    FText::FromString(FString::Printf(TEXT("Check if a newer version of the %s Server SDK is available."), *ULootLockerServerConfig::PackageName)),
+                    FText::FromString(TEXT("Check if a newer version of the LootLocker Server SDK is available.")),
                     FSlateIcon(),
                     FUIAction(FExecuteAction::CreateStatic(&FLootLockerServerUpdateChecker::ManualCheck))
                 );

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerSDKEditor.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerSDKEditor.cpp
@@ -6,8 +6,11 @@
 #include "ToolMenus.h"
 #include "Widgets/Layout/SBox.h"
 #include "LootLockerServerLogViewerWidget.h"
+#include "LootLockerServerUpdateChecker.h"
 #include "Editor.h"
 #include "Editor/EditorEngine.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Misc/App.h"
 
 static const FName LootLockerServerLogViewerTabName("LootLockerServerLogViewerTab");
 
@@ -16,6 +19,12 @@ class FLootLockerServerSDKEditorModule : public IModuleInterface
 public:
     virtual void StartupModule() override
     {
+        // Do not register Slate widgets in headless/unattended mode (automated tests, commandlets).
+        if (FApp::IsUnattended() || !FSlateApplication::IsInitialized())
+        {
+            return;
+        }
+
         FGlobalTabmanager::Get()->RegisterNomadTabSpawner(LootLockerServerLogViewerTabName,
             FOnSpawnTab::CreateLambda([](const FSpawnTabArgs& Args) {
                 return SNew(SDockTab)
@@ -33,12 +42,33 @@ public:
             if (Menu)
             {
                 FToolMenuSection& Section = Menu->AddSection("LootLocker Tools", FText::FromString("LootLocker Tools"));
+                Section.AddMenuEntry(
+                    "LootLockerServerLogViewerMenuEntry",
+                    FText::FromString("LootLocker Server Log Viewer"),
+                    FText::FromString("Open the LootLocker Server Log Viewer window."),
+                    FSlateIcon(),
+                    FUIAction(FExecuteAction::CreateLambda([]
+                    {
+                        FGlobalTabmanager::Get()->TryInvokeTab(LootLockerServerLogViewerTabName);
+                    }))
+                );
+                Section.AddMenuEntry(
+                    "LootLockerServerCheckForUpdates",
+                    FText::FromString("Check for Updates"),
+                    FText::FromString("Check if a newer version of the LootLocker Server SDK is available."),
+                    FSlateIcon(),
+                    FUIAction(FExecuteAction::CreateStatic(&FLootLockerServerUpdateChecker::ManualCheck))
+                );
             }
         }));
+
+        // Delayed update check (fires after StartupDelaySeconds)
+        FLootLockerServerUpdateChecker::Initialize();
     }
 
     virtual void ShutdownModule() override
     {
+        FLootLockerServerUpdateChecker::Shutdown();
         FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(LootLockerServerLogViewerTabName);
     }
 };

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2025 LootLocker
 #include "LootLockerServerUpdateChecker.h"
-#include "LootLockerServerConfig.h"
 #include "SLootLockerServerUpdateNotification.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
@@ -125,7 +124,7 @@ void FLootLockerServerUpdateChecker::OnResponseReceived(
                 Response.IsValid() ? Response->GetResponseCode() : 0);
 
             FNotificationInfo Info(FText::FromString(
-                FString::Printf(TEXT("%s Server SDK: Could not reach GitHub to check for updates."), *ULootLockerServerConfig::PackageName)));
+                TEXT("LootLocker Server SDK: Could not reach GitHub to check for updates.")));
             Info.ExpireDuration = 5.0f;
             Info.bFireAndForget = true;
             FSlateNotificationManager::Get().AddNotification(Info);
@@ -196,7 +195,7 @@ void FLootLockerServerUpdateChecker::ShowUpdateNotification(
     }
 
     const TSharedRef<SWindow> Window = SNew(SWindow)
-        .Title(FText::FromString(FString::Printf(TEXT("%s Server SDK Update Available"), *ULootLockerServerConfig::PackageName)))
+        .Title(FText::FromString(TEXT("LootLocker Server SDK Update Available")))
         .ClientSize(FVector2D(580.0f, 210.0f))
         .SupportsMinimize(false)
         .SupportsMaximize(false)
@@ -217,7 +216,7 @@ void FLootLockerServerUpdateChecker::ShowUpdateNotification(
 void FLootLockerServerUpdateChecker::ShowUpToDateNotification()
 {
     FNotificationInfo Info(FText::FromString(
-        FString::Printf(TEXT("%s Server SDK is up to date!"), *ULootLockerServerConfig::PackageName)));
+        TEXT("LootLocker Server SDK is up to date!")));
     Info.ExpireDuration = 5.0f;
     Info.bFireAndForget = true;
     FSlateNotificationManager::Get().AddNotification(Info);

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
@@ -21,7 +21,6 @@ DEFINE_LOG_CATEGORY_STATIC(LogLootLockerServerSDKEditor, Log, All);
 
 // --- Static member definitions ---
 FTSTicker::FDelegateHandle FLootLockerServerUpdateChecker::TickerHandle;
-double FLootLockerServerUpdateChecker::ElapsedStartupSeconds = 0.0;
 const TCHAR* FLootLockerServerUpdateChecker::ConfigSection =
     TEXT("/Script/LootLockerServerSDKEditor.UpdateChecker");
 const TCHAR* FLootLockerServerUpdateChecker::GitHubReleasesUrl =
@@ -31,10 +30,10 @@ const TCHAR* FLootLockerServerUpdateChecker::GitHubReleasesUrl =
 
 void FLootLockerServerUpdateChecker::Initialize()
 {
-    ElapsedStartupSeconds = 0.0;
+    // Fire once after StartupDelaySeconds — return false in the callback to auto-unregister.
     TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
         FTickerDelegate::CreateStatic(&FLootLockerServerUpdateChecker::OnStartupTick),
-        0.0f
+        StartupDelaySeconds
     );
 }
 
@@ -54,14 +53,8 @@ void FLootLockerServerUpdateChecker::ManualCheck()
 
 bool FLootLockerServerUpdateChecker::OnStartupTick(float DeltaTime)
 {
-    ElapsedStartupSeconds += DeltaTime;
-    if (ElapsedStartupSeconds >= StartupDelaySeconds)
-    {
-        TickerHandle.Reset();
-        CheckForUpdate(/*bManual=*/false);
-        return false;
-    }
-    return true;
+    CheckForUpdate(/*bManual=*/false);
+    return false;  // one-shot — unregister immediately
 }
 
 void FLootLockerServerUpdateChecker::CheckForUpdate(bool bManual)
@@ -150,8 +143,15 @@ void FLootLockerServerUpdateChecker::OnResponseReceived(
         return;
     }
 
-    FString TagName = JsonObject->GetStringField(TEXT("tag_name"));
-    const FString HtmlUrl = JsonObject->GetStringField(TEXT("html_url"));
+    FString TagName;
+    FString HtmlUrl;
+    if (!JsonObject->TryGetStringField(TEXT("tag_name"), TagName) ||
+        !JsonObject->TryGetStringField(TEXT("html_url"), HtmlUrl))
+    {
+        UE_LOG(LogLootLockerServerSDKEditor, Warning,
+            TEXT("LootLocker Server SDK update check: GitHub response is missing expected fields."));
+        return;
+    }
 
     // Strip leading 'v' or 'V'
     if (TagName.StartsWith(TEXT("v")) || TagName.StartsWith(TEXT("V")))
@@ -177,7 +177,7 @@ void FLootLockerServerUpdateChecker::OnResponseReceived(
     {
         if (bManual || ShouldNotify(TagName))
         {
-            ShowUpdateNotification(TagName, HtmlUrl, bManual);
+            ShowUpdateNotification(TagName, HtmlUrl);
         }
     }
     else if (bManual)
@@ -187,7 +187,7 @@ void FLootLockerServerUpdateChecker::OnResponseReceived(
 }
 
 void FLootLockerServerUpdateChecker::ShowUpdateNotification(
-    const FString& LatestVersion, const FString& ReleaseUrl, bool bManual)
+    const FString& LatestVersion, const FString& ReleaseUrl)
 {
     if (!FSlateApplication::IsInitialized())
     {

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
@@ -20,7 +20,11 @@
 DEFINE_LOG_CATEGORY_STATIC(LogLootLockerServerSDKEditor, Log, All);
 
 // --- Static member definitions ---
+#if ENGINE_MAJOR_VERSION >= 5
 FTSTicker::FDelegateHandle FLootLockerServerUpdateChecker::TickerHandle;
+#else
+FDelegateHandle FLootLockerServerUpdateChecker::TickerHandle;
+#endif
 const TCHAR* FLootLockerServerUpdateChecker::ConfigSection =
     TEXT("/Script/LootLockerServerSDKEditor.UpdateChecker");
 const TCHAR* FLootLockerServerUpdateChecker::GitHubReleasesUrl =
@@ -31,17 +35,28 @@ const TCHAR* FLootLockerServerUpdateChecker::GitHubReleasesUrl =
 void FLootLockerServerUpdateChecker::Initialize()
 {
     // Fire once after StartupDelaySeconds — return false in the callback to auto-unregister.
+#if ENGINE_MAJOR_VERSION >= 5
     TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
         FTickerDelegate::CreateStatic(&FLootLockerServerUpdateChecker::OnStartupTick),
         StartupDelaySeconds
     );
+#else
+    TickerHandle = FTicker::GetCoreTicker().AddTicker(
+        FTickerDelegate::CreateStatic(&FLootLockerServerUpdateChecker::OnStartupTick),
+        StartupDelaySeconds
+    );
+#endif
 }
 
 void FLootLockerServerUpdateChecker::Shutdown()
 {
     if (TickerHandle.IsValid())
     {
+#if ENGINE_MAJOR_VERSION >= 5
         FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
+#else
+        FTicker::GetCoreTicker().RemoveTicker(TickerHandle);
+#endif
         TickerHandle.Reset();
     }
 }
@@ -96,7 +111,7 @@ bool FLootLockerServerUpdateChecker::ShouldNotify(const FString& LatestVersion)
 
 void FLootLockerServerUpdateChecker::FetchLatestRelease(bool bManual)
 {
-    TSharedRef<IHttpRequest> Request = FHttpModule::Get().CreateRequest();
+    FHttpRequestPtr Request = FHttpModule::Get().CreateRequest();
     Request->SetURL(GitHubReleasesUrl);
     Request->SetVerb(TEXT("GET"));
     Request->SetHeader(TEXT("Accept"), TEXT("application/vnd.github.v3+json"));

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 LootLocker
 #include "LootLockerServerUpdateChecker.h"
+#include "LootLockerServerConfig.h"
 #include "SLootLockerServerUpdateNotification.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
@@ -124,7 +125,7 @@ void FLootLockerServerUpdateChecker::OnResponseReceived(
                 Response.IsValid() ? Response->GetResponseCode() : 0);
 
             FNotificationInfo Info(FText::FromString(
-                TEXT("LootLocker Server SDK: Could not reach GitHub to check for updates.")));
+                FString::Printf(TEXT("%s Server SDK: Could not reach GitHub to check for updates."), *ULootLockerServerConfig::PackageName)));
             Info.ExpireDuration = 5.0f;
             Info.bFireAndForget = true;
             FSlateNotificationManager::Get().AddNotification(Info);
@@ -195,7 +196,7 @@ void FLootLockerServerUpdateChecker::ShowUpdateNotification(
     }
 
     const TSharedRef<SWindow> Window = SNew(SWindow)
-        .Title(FText::FromString(TEXT("LootLocker Server SDK Update Available")))
+        .Title(FText::FromString(FString::Printf(TEXT("%s Server SDK Update Available"), *ULootLockerServerConfig::PackageName)))
         .ClientSize(FVector2D(580.0f, 210.0f))
         .SupportsMinimize(false)
         .SupportsMaximize(false)
@@ -215,7 +216,8 @@ void FLootLockerServerUpdateChecker::ShowUpdateNotification(
 
 void FLootLockerServerUpdateChecker::ShowUpToDateNotification()
 {
-    FNotificationInfo Info(FText::FromString(TEXT("LootLocker Server SDK is up to date!")));
+    FNotificationInfo Info(FText::FromString(
+        FString::Printf(TEXT("%s Server SDK is up to date!"), *ULootLockerServerConfig::PackageName)));
     Info.ExpireDuration = 5.0f;
     Info.bFireAndForget = true;
     FSlateNotificationManager::Get().AddNotification(Info);

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.cpp
@@ -1,0 +1,314 @@
+// Copyright (c) 2025 LootLocker
+#include "LootLockerServerUpdateChecker.h"
+#include "SLootLockerServerUpdateNotification.h"
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+#include "Interfaces/IPluginManager.h"
+#include "Misc/DateTime.h"
+#include "Misc/ConfigCacheIni.h"
+#include "Containers/Ticker.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+#include "HAL/PlatformProcess.h"
+#include "Logging/LogMacros.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogLootLockerServerSDKEditor, Log, All);
+
+// --- Static member definitions ---
+FTSTicker::FDelegateHandle FLootLockerServerUpdateChecker::TickerHandle;
+double FLootLockerServerUpdateChecker::ElapsedStartupSeconds = 0.0;
+const TCHAR* FLootLockerServerUpdateChecker::ConfigSection =
+    TEXT("/Script/LootLockerServerSDKEditor.UpdateChecker");
+const TCHAR* FLootLockerServerUpdateChecker::GitHubReleasesUrl =
+    TEXT("https://api.github.com/repos/lootlocker/unreal-server-sdk/releases/latest");
+
+// ---------------------------------------------------------------------------
+
+void FLootLockerServerUpdateChecker::Initialize()
+{
+    ElapsedStartupSeconds = 0.0;
+    TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
+        FTickerDelegate::CreateStatic(&FLootLockerServerUpdateChecker::OnStartupTick),
+        0.0f
+    );
+}
+
+void FLootLockerServerUpdateChecker::Shutdown()
+{
+    if (TickerHandle.IsValid())
+    {
+        FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
+        TickerHandle.Reset();
+    }
+}
+
+void FLootLockerServerUpdateChecker::ManualCheck()
+{
+    CheckForUpdate(/*bManual=*/true);
+}
+
+bool FLootLockerServerUpdateChecker::OnStartupTick(float DeltaTime)
+{
+    ElapsedStartupSeconds += DeltaTime;
+    if (ElapsedStartupSeconds >= StartupDelaySeconds)
+    {
+        TickerHandle.Reset();
+        CheckForUpdate(/*bManual=*/false);
+        return false;
+    }
+    return true;
+}
+
+void FLootLockerServerUpdateChecker::CheckForUpdate(bool bManual)
+{
+    if (!bManual && !ShouldCheck())
+    {
+        return;
+    }
+    FetchLatestRelease(bManual);
+}
+
+bool FLootLockerServerUpdateChecker::ShouldCheck()
+{
+    if (GetNeverNotify())
+    {
+        return false;
+    }
+
+    const FDateTime RemindAfter = GetRemindAfterTime();
+    if (FDateTime::UtcNow() < RemindAfter)
+    {
+        return false;
+    }
+
+    const FDateTime LastChecked = GetLastCheckedTime();
+    const FTimespan TimeSinceLastCheck = FDateTime::UtcNow() - LastChecked;
+    if (TimeSinceLastCheck.GetTotalHours() < CheckIntervalHours)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool FLootLockerServerUpdateChecker::ShouldNotify(const FString& LatestVersion)
+{
+    return GetSkippedVersion() != LatestVersion;
+}
+
+void FLootLockerServerUpdateChecker::FetchLatestRelease(bool bManual)
+{
+    TSharedRef<IHttpRequest> Request = FHttpModule::Get().CreateRequest();
+    Request->SetURL(GitHubReleasesUrl);
+    Request->SetVerb(TEXT("GET"));
+    Request->SetHeader(TEXT("Accept"), TEXT("application/vnd.github.v3+json"));
+    Request->SetHeader(TEXT("User-Agent"), TEXT("LootLockerServerSDK-UnrealEditor"));
+
+    Request->OnProcessRequestComplete().BindLambda(
+        [bManual](FHttpRequestPtr Req, FHttpResponsePtr Resp, bool bWasSuccessful)
+        {
+            FLootLockerServerUpdateChecker::OnResponseReceived(Req, Resp, bWasSuccessful, bManual);
+        }
+    );
+
+    Request->ProcessRequest();
+}
+
+void FLootLockerServerUpdateChecker::OnResponseReceived(
+    FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual)
+{
+    if (!bWasSuccessful || !Response.IsValid() || Response->GetResponseCode() != 200)
+    {
+        if (bManual)
+        {
+            UE_LOG(LogLootLockerServerSDKEditor, Warning,
+                TEXT("LootLocker Server SDK update check failed (HTTP %d)."),
+                Response.IsValid() ? Response->GetResponseCode() : 0);
+
+            FNotificationInfo Info(FText::FromString(
+                TEXT("LootLocker Server SDK: Could not reach GitHub to check for updates.")));
+            Info.ExpireDuration = 5.0f;
+            Info.bFireAndForget = true;
+            FSlateNotificationManager::Get().AddNotification(Info);
+        }
+        return;
+    }
+
+    TSharedPtr<FJsonObject> JsonObject;
+    const TSharedRef<TJsonReader<>> Reader =
+        TJsonReaderFactory<>::Create(Response->GetContentAsString());
+
+    if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid())
+    {
+        UE_LOG(LogLootLockerServerSDKEditor, Warning,
+            TEXT("LootLocker Server SDK update check: failed to parse GitHub response."));
+        return;
+    }
+
+    FString TagName = JsonObject->GetStringField(TEXT("tag_name"));
+    const FString HtmlUrl = JsonObject->GetStringField(TEXT("html_url"));
+
+    // Strip leading 'v' or 'V'
+    if (TagName.StartsWith(TEXT("v")) || TagName.StartsWith(TEXT("V")))
+    {
+        TagName.RightChopInline(1);
+    }
+
+    // Strip pre-release suffix
+    int32 DashIndex;
+    if (TagName.FindChar(TEXT('-'), DashIndex))
+    {
+        TagName = TagName.Left(DashIndex);
+    }
+    int32 PlusIndex;
+    if (TagName.FindChar(TEXT('+'), PlusIndex))
+    {
+        TagName = TagName.Left(PlusIndex);
+    }
+
+    SaveLastCheckedTime(FDateTime::UtcNow());
+
+    if (IsVersionNewer(TagName, GetCurrentVersion()))
+    {
+        if (bManual || ShouldNotify(TagName))
+        {
+            ShowUpdateNotification(TagName, HtmlUrl, bManual);
+        }
+    }
+    else if (bManual)
+    {
+        ShowUpToDateNotification();
+    }
+}
+
+void FLootLockerServerUpdateChecker::ShowUpdateNotification(
+    const FString& LatestVersion, const FString& ReleaseUrl, bool bManual)
+{
+    if (!FSlateApplication::IsInitialized())
+    {
+        return;
+    }
+
+    const TSharedRef<SWindow> Window = SNew(SWindow)
+        .Title(FText::FromString(TEXT("LootLocker Server SDK Update Available")))
+        .ClientSize(FVector2D(580.0f, 210.0f))
+        .SupportsMinimize(false)
+        .SupportsMaximize(false)
+        .IsTopmostWindow(false)
+        .SizingRule(ESizingRule::FixedSize);
+
+    Window->SetContent(
+        SNew(SLootLockerServerUpdateNotification)
+            .CurrentVersion(GetCurrentVersion())
+            .LatestVersion(LatestVersion)
+            .ReleaseUrl(ReleaseUrl)
+            .ParentWindow(Window)
+    );
+
+    FSlateApplication::Get().AddWindow(Window);
+}
+
+void FLootLockerServerUpdateChecker::ShowUpToDateNotification()
+{
+    FNotificationInfo Info(FText::FromString(TEXT("LootLocker Server SDK is up to date!")));
+    Info.ExpireDuration = 5.0f;
+    Info.bFireAndForget = true;
+    FSlateNotificationManager::Get().AddNotification(Info);
+}
+
+bool FLootLockerServerUpdateChecker::IsVersionNewer(
+    const FString& RemoteVersion, const FString& LocalVersion)
+{
+    TArray<FString> RemoteParts, LocalParts;
+    RemoteVersion.ParseIntoArray(RemoteParts, TEXT("."));
+    LocalVersion.ParseIntoArray(LocalParts, TEXT("."));
+
+    const int32 MaxParts = FMath::Max(RemoteParts.Num(), LocalParts.Num());
+    for (int32 i = 0; i < MaxParts; ++i)
+    {
+        const int32 Remote = (i < RemoteParts.Num()) ? FCString::Atoi(*RemoteParts[i]) : 0;
+        const int32 Local  = (i < LocalParts.Num())  ? FCString::Atoi(*LocalParts[i])  : 0;
+        if (Remote > Local) return true;
+        if (Remote < Local) return false;
+    }
+    return false;
+}
+
+FString FLootLockerServerUpdateChecker::GetCurrentVersion()
+{
+    const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("LootLockerServerSDK"));
+    if (Plugin.IsValid())
+    {
+        return Plugin->GetDescriptor().VersionName;
+    }
+    return TEXT("0.0.0");
+}
+
+// --- Config helpers ---
+
+bool FLootLockerServerUpdateChecker::GetNeverNotify()
+{
+    bool bValue = false;
+    GConfig->GetBool(ConfigSection, TEXT("NeverNotify"), bValue, GEditorPerProjectIni);
+    return bValue;
+}
+
+void FLootLockerServerUpdateChecker::SetNeverNotify(bool bValue)
+{
+    GConfig->SetBool(ConfigSection, TEXT("NeverNotify"), bValue, GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FString FLootLockerServerUpdateChecker::GetSkippedVersion()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("SkippedVersion"), Value, GEditorPerProjectIni);
+    return Value;
+}
+
+void FLootLockerServerUpdateChecker::SetSkippedVersion(const FString& Version)
+{
+    GConfig->SetString(ConfigSection, TEXT("SkippedVersion"), *Version, GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FDateTime FLootLockerServerUpdateChecker::GetRemindAfterTime()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("RemindAfterUtc"), Value, GEditorPerProjectIni);
+    FDateTime Result;
+    if (FDateTime::ParseIso8601(*Value, Result))
+    {
+        return Result;
+    }
+    return FDateTime::MinValue();
+}
+
+void FLootLockerServerUpdateChecker::SetRemindAfterTime(const FDateTime& Time)
+{
+    GConfig->SetString(ConfigSection, TEXT("RemindAfterUtc"), *Time.ToIso8601(), GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}
+
+FDateTime FLootLockerServerUpdateChecker::GetLastCheckedTime()
+{
+    FString Value;
+    GConfig->GetString(ConfigSection, TEXT("LastCheckedUtc"), Value, GEditorPerProjectIni);
+    FDateTime Result;
+    if (FDateTime::ParseIso8601(*Value, Result))
+    {
+        return Result;
+    }
+    return FDateTime::MinValue();
+}
+
+void FLootLockerServerUpdateChecker::SaveLastCheckedTime(const FDateTime& Time)
+{
+    GConfig->SetString(ConfigSection, TEXT("LastCheckedUtc"), *Time.ToIso8601(), GEditorPerProjectIni);
+    GConfig->Flush(false, GEditorPerProjectIni);
+}

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 LootLocker
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Containers/Ticker.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+
+/**
+ * Editor-only utility that checks GitHub Releases for a newer LootLocker Server SDK version
+ * and shows a non-blocking notification window when one is available.
+ *
+ * Call Initialize() from StartupModule() and Shutdown() from ShutdownModule().
+ * The automatic check fires once after a 180-second startup delay, then at most once
+ * every 24 hours. Silence and skip preferences are persisted via GConfig.
+ */
+class FLootLockerServerUpdateChecker
+{
+public:
+    /** Called from StartupModule — registers the delayed startup ticker. */
+    static void Initialize();
+
+    /** Called from ShutdownModule — removes the ticker handle. */
+    static void Shutdown();
+
+    /** Manual check triggered from the Tools menu. Bypasses throttle and silence settings. */
+    static void ManualCheck();
+
+    // Called by SLootLockerServerUpdateNotification button handlers
+    static void SetNeverNotify(bool bValue);
+    static void SetSkippedVersion(const FString& Version);
+    static void SetRemindAfterTime(const FDateTime& Time);
+
+private:
+    static bool OnStartupTick(float DeltaTime);
+
+    static void CheckForUpdate(bool bManual);
+
+    /** Returns true if the automatic check should proceed (throttle + silence guards). */
+    static bool ShouldCheck();
+
+    /** Returns true if the notification window should be shown for LatestVersion. */
+    static bool ShouldNotify(const FString& LatestVersion);
+
+    static void FetchLatestRelease(bool bManual);
+
+    static void OnResponseReceived(
+        FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual);
+
+    static void ShowUpdateNotification(
+        const FString& LatestVersion, const FString& ReleaseUrl, bool bManual);
+
+    static void ShowUpToDateNotification();
+
+    /** Numeric semver comparison — returns true if RemoteVersion is strictly newer than LocalVersion. */
+    static bool IsVersionNewer(const FString& RemoteVersion, const FString& LocalVersion);
+
+    /** Reads the current SDK version from the plugin descriptor. */
+    static FString GetCurrentVersion();
+
+    // --- Config helpers (GEditorPerProjectIni) ---
+    static bool GetNeverNotify();
+    static FString GetSkippedVersion();
+    static FDateTime GetRemindAfterTime();
+    static FDateTime GetLastCheckedTime();
+    static void SaveLastCheckedTime(const FDateTime& Time);
+
+    static FTSTicker::FDelegateHandle TickerHandle;
+    static double ElapsedStartupSeconds;
+
+    static constexpr double StartupDelaySeconds = 180.0;
+    static constexpr double CheckIntervalHours = 24.0;
+    static const TCHAR* ConfigSection;
+    static const TCHAR* GitHubReleasesUrl;
+};

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.h
@@ -65,7 +65,11 @@ private:
     static FDateTime GetLastCheckedTime();
     static void SaveLastCheckedTime(const FDateTime& Time);
 
+#if ENGINE_MAJOR_VERSION >= 5
     static FTSTicker::FDelegateHandle TickerHandle;
+#else
+    static FDelegateHandle TickerHandle;
+#endif
 
     static constexpr float StartupDelaySeconds = 180.0f;
     static constexpr double CheckIntervalHours = 24.0;

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/LootLockerServerUpdateChecker.h
@@ -48,7 +48,7 @@ private:
         FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, bool bManual);
 
     static void ShowUpdateNotification(
-        const FString& LatestVersion, const FString& ReleaseUrl, bool bManual);
+        const FString& LatestVersion, const FString& ReleaseUrl);
 
     static void ShowUpToDateNotification();
 
@@ -66,9 +66,8 @@ private:
     static void SaveLastCheckedTime(const FDateTime& Time);
 
     static FTSTicker::FDelegateHandle TickerHandle;
-    static double ElapsedStartupSeconds;
 
-    static constexpr double StartupDelaySeconds = 180.0;
+    static constexpr float StartupDelaySeconds = 180.0f;
     static constexpr double CheckIntervalHours = 24.0;
     static const TCHAR* ConfigSection;
     static const TCHAR* GitHubReleasesUrl;

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/SLootLockerServerUpdateNotification.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/SLootLockerServerUpdateNotification.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 LootLocker
 #include "SLootLockerServerUpdateNotification.h"
 #include "LootLockerServerUpdateChecker.h"
+#include "LootLockerServerConfig.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Text/STextBlock.h"
@@ -29,7 +30,7 @@ void SLootLockerServerUpdateNotification::Construct(const FArguments& InArgs)
             .Padding(0.0f, 0.0f, 0.0f, 8.0f)
             [
                 SNew(STextBlock)
-                .Text(FText::FromString(TEXT("A new version of the LootLocker Server SDK is available.")))
+                .Text(FText::FromString(FString::Printf(TEXT("A new version of the %s Server SDK is available."), *ULootLockerServerConfig::PackageName)))
                 .Font(FCoreStyle::GetDefaultFontStyle("Bold", 12))
             ]
 
@@ -81,6 +82,21 @@ void SLootLockerServerUpdateNotification::Construct(const FArguments& InArgs)
                     .Text(FText::FromString(TEXT("See what's new \u2197")))
                     .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.6f, 1.0f)))
                 ]
+            ]
+
+            // Powered-by notice (shown when SDK is rebranded by a publisher)
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 8.0f)
+            [
+                SNew(STextBlock)
+                .Visibility(ULootLockerServerConfig::PackageName != TEXT("LootLocker")
+                    ? EVisibility::Visible : EVisibility::Collapsed)
+                .Text(FText::FromString(FString::Printf(
+                    TEXT("%s Server SDK is powered by LootLocker \u2014 release notes are on the LootLocker GitHub page."),
+                    *ULootLockerServerConfig::PackageName)))
+                .ColorAndOpacity(FSlateColor(FLinearColor(0.5f, 0.5f, 0.5f)))
+                .AutoWrapText(true)
             ]
 
             // Action buttons — fill available width evenly

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/SLootLockerServerUpdateNotification.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/SLootLockerServerUpdateNotification.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2025 LootLocker
 #include "SLootLockerServerUpdateNotification.h"
 #include "LootLockerServerUpdateChecker.h"
-#include "LootLockerServerConfig.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Text/STextBlock.h"
@@ -30,7 +29,7 @@ void SLootLockerServerUpdateNotification::Construct(const FArguments& InArgs)
             .Padding(0.0f, 0.0f, 0.0f, 8.0f)
             [
                 SNew(STextBlock)
-                .Text(FText::FromString(FString::Printf(TEXT("A new version of the %s Server SDK is available."), *ULootLockerServerConfig::PackageName)))
+                .Text(FText::FromString(TEXT("A new version of the LootLocker Server SDK is available.")))
                 .Font(FCoreStyle::GetDefaultFontStyle("Bold", 12))
             ]
 
@@ -82,21 +81,6 @@ void SLootLockerServerUpdateNotification::Construct(const FArguments& InArgs)
                     .Text(FText::FromString(TEXT("See what's new \u2197")))
                     .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.6f, 1.0f)))
                 ]
-            ]
-
-            // Powered-by notice (shown when SDK is rebranded by a publisher)
-            + SVerticalBox::Slot()
-            .AutoHeight()
-            .Padding(0.0f, 0.0f, 0.0f, 8.0f)
-            [
-                SNew(STextBlock)
-                .Visibility(ULootLockerServerConfig::PackageName != TEXT("LootLocker")
-                    ? EVisibility::Visible : EVisibility::Collapsed)
-                .Text(FText::FromString(FString::Printf(
-                    TEXT("%s Server SDK is powered by LootLocker \u2014 release notes are on the LootLocker GitHub page."),
-                    *ULootLockerServerConfig::PackageName)))
-                .ColorAndOpacity(FSlateColor(FLinearColor(0.5f, 0.5f, 0.5f)))
-                .AutoWrapText(true)
             ]
 
             // Action buttons — fill available width evenly

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/SLootLockerServerUpdateNotification.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/SLootLockerServerUpdateNotification.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2025 LootLocker
+#include "SLootLockerServerUpdateNotification.h"
+#include "LootLockerServerUpdateChecker.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/SBoxPanel.h"
+#include "HAL/PlatformProcess.h"
+#include "Framework/Application/SlateApplication.h"
+
+void SLootLockerServerUpdateNotification::Construct(const FArguments& InArgs)
+{
+    CurrentVersion = InArgs._CurrentVersion;
+    LatestVersion  = InArgs._LatestVersion;
+    ReleaseUrl     = InArgs._ReleaseUrl;
+    ParentWindow   = InArgs._ParentWindow;
+
+    ChildSlot
+    [
+        SNew(SBorder)
+        .Padding(FMargin(16.0f))
+        [
+            SNew(SVerticalBox)
+
+            // Header
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 8.0f)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(TEXT("A new version of the LootLocker Server SDK is available.")))
+                .Font(FCoreStyle::GetDefaultFontStyle("Bold", 12))
+            ]
+
+            // Version info
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 4.0f)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock).Text(FText::FromString(TEXT("Installed:  ")))
+                ]
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("v%s"), *CurrentVersion)))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.6f, 0.6f, 0.6f)))
+                ]
+            ]
+
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 12.0f)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock).Text(FText::FromString(TEXT("Available:  ")))
+                ]
+                + SHorizontalBox::Slot().AutoWidth()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("v%s"), *LatestVersion)))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.8f, 0.2f)))
+                ]
+            ]
+
+            // "See what's new" link button
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, 16.0f)
+            [
+                SNew(SButton)
+                .ButtonStyle(FCoreStyle::Get(), "NoBorder")
+                .OnClicked(this, &SLootLockerServerUpdateNotification::OnSeeWhatsNewClicked)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(TEXT("See what's new \u2197")))
+                    .ColorAndOpacity(FSlateColor(FLinearColor(0.2f, 0.6f, 1.0f)))
+                ]
+            ]
+
+            // Action buttons — fill available width evenly
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            [
+                SNew(SHorizontalBox)
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Update Now")))
+                    .OnClicked(this, &SLootLockerServerUpdateNotification::OnUpdateNowClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Skip This Version")))
+                    .OnClicked(this, &SLootLockerServerUpdateNotification::OnSkipVersionClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .Padding(0.0f, 0.0f, 4.0f, 0.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Remind in 7 Days")))
+                    .OnClicked(this, &SLootLockerServerUpdateNotification::OnRemindLaterClicked)
+                ]
+
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                [
+                    SNew(SButton)
+                    .HAlign(HAlign_Center)
+                    .Text(FText::FromString(TEXT("Never Notify Me")))
+                    .OnClicked(this, &SLootLockerServerUpdateNotification::OnNeverNotifyClicked)
+                ]
+            ]
+        ]
+    ];
+}
+
+FReply SLootLockerServerUpdateNotification::OnSeeWhatsNewClicked()
+{
+    if (!ReleaseUrl.IsEmpty() && ReleaseUrl.StartsWith(TEXT("https://github.com/")))
+    {
+        FPlatformProcess::LaunchURL(*ReleaseUrl, nullptr, nullptr);
+    }
+    return FReply::Handled();
+}
+
+FReply SLootLockerServerUpdateNotification::OnUpdateNowClicked()
+{
+    if (!ReleaseUrl.IsEmpty() && ReleaseUrl.StartsWith(TEXT("https://github.com/")))
+    {
+        FPlatformProcess::LaunchURL(*ReleaseUrl, nullptr, nullptr);
+    }
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerServerUpdateNotification::OnSkipVersionClicked()
+{
+    FLootLockerServerUpdateChecker::SetSkippedVersion(LatestVersion);
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerServerUpdateNotification::OnRemindLaterClicked()
+{
+    FLootLockerServerUpdateChecker::SetRemindAfterTime(
+        FDateTime::UtcNow() + FTimespan::FromDays(7.0));
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+FReply SLootLockerServerUpdateNotification::OnNeverNotifyClicked()
+{
+    FLootLockerServerUpdateChecker::SetNeverNotify(true);
+    CloseParentWindow();
+    return FReply::Handled();
+}
+
+void SLootLockerServerUpdateNotification::CloseParentWindow()
+{
+    if (const TSharedPtr<SWindow> Window = ParentWindow.Pin())
+    {
+        Window->RequestDestroyWindow();
+    }
+}

--- a/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/SLootLockerServerUpdateNotification.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDKEditor/Private/SLootLockerServerUpdateNotification.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 LootLocker
+#pragma once
+
+#include "Widgets/SCompoundWidget.h"
+#include "Templates/SharedPointer.h"
+
+/**
+ * Non-modal Slate window content shown when a newer LootLocker Server SDK version is available.
+ * Hosted inside an SWindow created by FLootLockerServerUpdateChecker::ShowUpdateNotification().
+ */
+class SLootLockerServerUpdateNotification : public SCompoundWidget
+{
+public:
+    SLATE_BEGIN_ARGS(SLootLockerServerUpdateNotification) {}
+        SLATE_ARGUMENT(FString, CurrentVersion)
+        SLATE_ARGUMENT(FString, LatestVersion)
+        SLATE_ARGUMENT(FString, ReleaseUrl)
+        SLATE_ARGUMENT(TSharedPtr<SWindow>, ParentWindow)
+    SLATE_END_ARGS()
+
+    void Construct(const FArguments& InArgs);
+
+private:
+    FReply OnSeeWhatsNewClicked();
+    FReply OnUpdateNowClicked();
+    FReply OnSkipVersionClicked();
+    FReply OnRemindLaterClicked();
+    FReply OnNeverNotifyClicked();
+
+    void CloseParentWindow();
+
+    FString CurrentVersion;
+    FString LatestVersion;
+    FString ReleaseUrl;
+    TWeakPtr<SWindow> ParentWindow;
+};


### PR DESCRIPTION
# LootLocker_UnrealServerSDK_V6.6.0

### Features

• 🛒 **Catalog API** — A new catalog endpoint: `ListCatalogItemsById` (look up up to 100 catalog entries by `catalog_listing_id`). Response includes comprehensive entity detail structs for assets, currencies, progression points, progression resets, and groups with inlined metadata parsing.

• 🏆 **Leaderboard Manual Reset CRUD** — Four new endpoints for managing leaderboard resets from the server: `RequestManualLeaderboardReset`, `ListManualLeaderboardResets`, `GetManualLeaderboardReset`, and `CancelManualLeaderboardReset`. Each response includes scheduling information (`scheduled_for`), status tracking (`pending`/`processing`/`completed`/`failed`), and error messages when a reset cannot be fulfilled.

• 🔧 **File-Based Pre-Configuration** — New `LootLockerServerPreConfig.bytes` system for shipping SDK settings in a file instead of `DefaultGame.ini`. Supports plain JSON or AES-256-ECB + PKCS7 + Base64 encrypted content. Covers `api_key`, `domain_key`, `game_version`, `log_level`, and logging flags. When active, locks the Project Settings UI to prevent accidental drift between the file and the editor. Useful for CI/CD pipelines and distribution where settings should not live in version-controlled ini files.

• 📣 **In-Editor Update Checker** — A new "Check for Updates" entry under **Tools → LootLocker Tools** queries GitHub Releases for newer SDK versions and shows a non-modal notification window with the current vs. available version. Includes options to skip a version, remind in 7 days, or never notify. Automatically checks on editor startup (after a 180-second delay) and at most once every 24 hours. Preferences are persisted per-project.

### Fixes

• Fixed a crash in headless/unattended environments (commandlets, automated tests) where the editor module tried to register Slate widgets before Slate was initialized.

• Fixed `FindPlugin` call in the HTTP client to use the `TEXT()` macro for correct string literal handling.

### Breaking Changes

• **`LimitLogLevelTo` default changed from `Display` to `Warning`.** Existing projects that relied on `Display`-level logging will now see fewer log messages. If you need the previous behavior, explicitly set the log level to `Display` in Project Settings or via the file config system.

Full Changelog: [v6.5.0...v6.6.0](https://github.com/lootlocker/unreal-server-sdk/compare/v6.5.0...v6.6.0)