### PR TITLE
Add asset sorting (order_by/order_direction) to ListAssets

### DIFF
--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForBlueprints.cpp
@@ -481,16 +481,16 @@ FString ULootLockerServerForBlueprints::GetAssetsByContext(int Count, int After,
     }), IncludeUGC);
 }
 
-FString ULootLockerServerForBlueprints::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseBP& OnCompletedRequest)
+FString ULootLockerServerForBlueprints::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, ELootLockerServerOrderAssetListBy OrderBy, ELootLockerServerOrderAssetListDirection OrderDirection, const FLootLockerServerListAssetsResponseBP& OnCompletedRequest)
 {
-    return ULootLockerServerForCpp::ListAssets(Request, PerPage, Page, FLootLockerServerListAssetsResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerListAssetsResponse& Response) {
+    return ULootLockerServerForCpp::ListAssets(Request, PerPage, Page, OrderBy, OrderDirection, FLootLockerServerListAssetsResponseDelegate::CreateLambda([OnCompletedRequest](const FLootLockerServerListAssetsResponse& Response) {
         OnCompletedRequest.ExecuteIfBound(Response);
     }));
 }
 
 FString ULootLockerServerForBlueprints::ListAssetsWithDefaultParameters(const FLootLockerServerListAssetsResponseBP& OnCompletedRequest)
 {
-    return ListAssets(FLootLockerServerListAssetsRequest(), 0, 0, OnCompletedRequest);
+    return ListAssets(FLootLockerServerListAssetsRequest(), 0, 0, ELootLockerServerOrderAssetListBy::None, ELootLockerServerOrderAssetListDirection::None, OnCompletedRequest);
 }
 
 FString ULootLockerServerForBlueprints::ListContexts(int PerPage, int Page, const FLootLockerServerListContextsResponseBP& OnCompletedRequest)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -365,6 +365,11 @@ FString ULootLockerServerForCpp::GetAssetsByContext(int Count, int After, int Co
     return ULootLockerServerAssetRequest::GetAssets(Count, After, Context, IncludeUGC, OnCompletedRequest);
 }
 
+FString ULootLockerServerForCpp::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
+{
+    return ListAssets(Request, PerPage, Page, ELootLockerServerOrderAssetListBy::None, ELootLockerServerOrderAssetListDirection::None, OnCompletedRequest);
+}
+
 FString ULootLockerServerForCpp::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, ELootLockerServerOrderAssetListBy OrderBy, ELootLockerServerOrderAssetListDirection OrderDirection, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
 {
     return ULootLockerServerAssetRequest::ListAssets(Request, PerPage, Page, OrderBy, OrderDirection, OnCompletedRequest);

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/LootLockerServerForCpp.cpp
@@ -365,14 +365,14 @@ FString ULootLockerServerForCpp::GetAssetsByContext(int Count, int After, int Co
     return ULootLockerServerAssetRequest::GetAssets(Count, After, Context, IncludeUGC, OnCompletedRequest);
 }
 
-FString ULootLockerServerForCpp::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
+FString ULootLockerServerForCpp::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, ELootLockerServerOrderAssetListBy OrderBy, ELootLockerServerOrderAssetListDirection OrderDirection, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
 {
-    return ULootLockerServerAssetRequest::ListAssets(Request, PerPage, Page, OnCompletedRequest);
+    return ULootLockerServerAssetRequest::ListAssets(Request, PerPage, Page, OrderBy, OrderDirection, OnCompletedRequest);
 }
 
 FString ULootLockerServerForCpp::ListAssetsWithDefaultParameters(const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
 {
-    return ListAssets(FLootLockerServerListAssetsRequest(), 0, 0, OnCompletedRequest);
+    return ListAssets(FLootLockerServerListAssetsRequest(), 0, 0, ELootLockerServerOrderAssetListBy::None, ELootLockerServerOrderAssetListDirection::None, OnCompletedRequest);
 }
 
 FString ULootLockerServerForCpp::ListContexts(int PerPage, int Page, const FLootLockerServerListContextsResponseDelegate& OnCompletedRequest)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerAssetRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerAssetRequest.cpp
@@ -57,6 +57,11 @@ FString ULootLockerServerAssetRequest::DeleteKeyValuePairFromAssetInstanceById(i
     return ULootLockerServerHttpClient::SendRequest<FLootLockerServerAssetInstanceKeyValuePairsListResponse>(FLootLockerServerEmptyRequest{}, ULootLockerServerEndpoints::DeleteKeyValuePairById, { PlayerID, AssetInstanceID, KeyValuePairID }, {}, OnCompletedRequest);
 }
 
+FString ULootLockerServerAssetRequest::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
+{
+    return ListAssets(Request, PerPage, Page, ELootLockerServerOrderAssetListBy::None, ELootLockerServerOrderAssetListDirection::None, OnCompletedRequest);
+}
+
 FString ULootLockerServerAssetRequest::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, ELootLockerServerOrderAssetListBy OrderBy, ELootLockerServerOrderAssetListDirection OrderDirection, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
 {
     TMultiMap<FString, FString> QueryParams;
@@ -64,11 +69,15 @@ FString ULootLockerServerAssetRequest::ListAssets(const FLootLockerServerListAss
     if(PerPage > 0) QueryParams.Add("per_page", FString::FromInt(PerPage));
     if(OrderBy != ELootLockerServerOrderAssetListBy::None)
     {
-        QueryParams.Add("order_by", ULootLockerServerEnumUtils::GetEnum(TEXT("ELootLockerServerOrderAssetListBy"), static_cast<int32>(OrderBy)).ToLower());
+        FString OrderByStr = ULootLockerServerEnumUtils::GetEnum(TEXT("ELootLockerServerOrderAssetListBy"), static_cast<int32>(OrderBy)).ToLower();
+        OrderByStr.ReplaceCharInline(TEXT(' '), TEXT('_'));
+        QueryParams.Add("order_by", OrderByStr);
     }
     if(OrderDirection != ELootLockerServerOrderAssetListDirection::None)
     {
-        QueryParams.Add("order_direction", ULootLockerServerEnumUtils::GetEnum(TEXT("ELootLockerServerOrderAssetListDirection"), static_cast<int32>(OrderDirection)).ToLower());
+        FString OrderDirectionStr = ULootLockerServerEnumUtils::GetEnum(TEXT("ELootLockerServerOrderAssetListDirection"), static_cast<int32>(OrderDirection)).ToLower();
+        OrderDirectionStr.ReplaceCharInline(TEXT(' '), TEXT('_'));
+        QueryParams.Add("order_direction", OrderDirectionStr);
     }
     return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListAssetsResponse>(Request, ULootLockerServerEndpoints::ListAssets, {}, QueryParams, OnCompletedRequest);
 }

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerAssetRequest.cpp
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Private/ServerAPI/LootLockerServerAssetRequest.cpp
@@ -57,11 +57,19 @@ FString ULootLockerServerAssetRequest::DeleteKeyValuePairFromAssetInstanceById(i
     return ULootLockerServerHttpClient::SendRequest<FLootLockerServerAssetInstanceKeyValuePairsListResponse>(FLootLockerServerEmptyRequest{}, ULootLockerServerEndpoints::DeleteKeyValuePairById, { PlayerID, AssetInstanceID, KeyValuePairID }, {}, OnCompletedRequest);
 }
 
-FString ULootLockerServerAssetRequest::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
+FString ULootLockerServerAssetRequest::ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, ELootLockerServerOrderAssetListBy OrderBy, ELootLockerServerOrderAssetListDirection OrderDirection, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest)
 {
     TMultiMap<FString, FString> QueryParams;
     if(Page > 0) QueryParams.Add("page", FString::FromInt(Page));
     if(PerPage > 0) QueryParams.Add("per_page", FString::FromInt(PerPage));
+    if(OrderBy != ELootLockerServerOrderAssetListBy::None)
+    {
+        QueryParams.Add("order_by", ULootLockerServerEnumUtils::GetEnum(TEXT("ELootLockerServerOrderAssetListBy"), static_cast<int32>(OrderBy)).ToLower());
+    }
+    if(OrderDirection != ELootLockerServerOrderAssetListDirection::None)
+    {
+        QueryParams.Add("order_direction", ULootLockerServerEnumUtils::GetEnum(TEXT("ELootLockerServerOrderAssetListDirection"), static_cast<int32>(OrderDirection)).ToLower());
+    }
     return ULootLockerServerHttpClient::SendRequest<FLootLockerServerListAssetsResponse>(Request, ULootLockerServerEndpoints::ListAssets, {}, QueryParams, OnCompletedRequest);
 }
 

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForBlueprints.h
@@ -1380,12 +1380,14 @@ public:
      * @param Request Request payload specifying includes/excludes/filters
      * @param PerPage Optional: page size (ignored if 0 or negative)
      * @param Page Optional: page index (ignored if 0 or negative)
+     * @param OrderBy Optional: field to order the asset list by
+     * @param OrderDirection Optional: direction to order the asset list
      * @param OnCompletedRequest Delegate for handling the server response
      * 
      * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
-    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Assets", meta=(AdvancedDisplay="PerPage,Page", PerPage=-1, Page=-1))
-    static UPARAM(DisplayName = "RequestId") FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseBP& OnCompletedRequest);
+    UFUNCTION(BlueprintCallable, Category = "LootLockerServer Methods | Assets", meta=(AdvancedDisplay="PerPage,Page,OrderBy,OrderDirection", PerPage=-1, Page=-1))
+    static UPARAM(DisplayName = "RequestId") FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, ELootLockerServerOrderAssetListBy OrderBy, ELootLockerServerOrderAssetListDirection OrderDirection, const FLootLockerServerListAssetsResponseBP& OnCompletedRequest);
 
     /**
     * List assets with default parameters (no filters, first page, default page size)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -141,10 +141,12 @@ public:
      * @param Request Request payload specifying includes/excludes/filters
      * @param PerPage Optional: page size (ignored if 0 or negative)
      * @param Page Optional: page index (ignored if 0 or negative)
+     * @param OrderBy Optional: field to order the asset list by (None, Id, Name, Created_at, Updated_at)
+     * @param OrderDirection Optional: direction to order the asset list (None, Asc, Desc)
      * @param OnCompletedRequest Delegate for handling the server response
      * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
      */
-    static FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest);
+    static FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, ELootLockerServerOrderAssetListBy OrderBy, ELootLockerServerOrderAssetListDirection OrderDirection, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest);
 
     /**
     * List assets with default parameters (no filters, first page, default page size)

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/LootLockerServerForCpp.h
@@ -141,6 +141,19 @@ public:
      * @param Request Request payload specifying includes/excludes/filters
      * @param PerPage Optional: page size (ignored if 0 or negative)
      * @param Page Optional: page index (ignored if 0 or negative)
+     * @param OnCompletedRequest Delegate for handling the server response
+     * @return A unique id for this request, use this to match callbacks to requests when you have multiple simultaneous requests outbound
+     *
+     * @deprecated Deprecated on 2026-07-17. Use the overload with OrderBy and OrderDirection parameters instead.
+     */
+    static FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest);
+
+    /**
+     * List assets with configurable response data and optional sorting. Use this to limit the fields returned in the response and improve performance.
+     * Lightweight alternative for retrieving assets where only selected data is needed
+     * @param Request Request payload specifying includes/excludes/filters
+     * @param PerPage Optional: page size (ignored if 0 or negative)
+     * @param Page Optional: page index (ignored if 0 or negative)
      * @param OrderBy Optional: field to order the asset list by (None, Id, Name, Created_at, Updated_at)
      * @param OrderDirection Optional: direction to order the asset list (None, Asc, Desc)
      * @param OnCompletedRequest Delegate for handling the server response

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
@@ -854,6 +854,8 @@ class LOOTLOCKERSERVERSDK_API ULootLockerServerAssetRequest : public UObject
     static FString UpdateKeyValuePairsOnAssetInstance(int PlayerID, int AssetInstanceID, TArray<FLootLockerServerAssetStorageKeyValueSet> KeyValuePairs, const FLootLockerServerAssetInstanceKeyValuePairsListResponseDelegate& OnCompletedRequest);
     static FString UpdateKeyValuePairOnAssetInstanceById(int PlayerID, int AssetInstanceID, int KeyValuePairID, const FString Key, FString Value, const FLootLockerServerAssetInstanceKeyValuePairItemResponseDelegate& OnCompletedRequest);
     static FString DeleteKeyValuePairFromAssetInstanceById(int PlayerID, int AssetInstanceID, int KeyValuePairID, const FLootLockerServerAssetInstanceKeyValuePairsListResponseDelegate& OnCompletedRequest);
+    // @deprecated Deprecated on 2026-07-17. Use the overload with OrderBy and OrderDirection parameters instead.
+    static FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage, int Page, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest);
     static FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage = 0, int Page = 0, ELootLockerServerOrderAssetListBy OrderBy = ELootLockerServerOrderAssetListBy::None, ELootLockerServerOrderAssetListDirection OrderDirection = ELootLockerServerOrderAssetListDirection::None, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest = FLootLockerServerListAssetsResponseDelegate());
     static FString ListContexts(int PerPage = 0, int Page = 0, const FLootLockerServerListContextsResponseDelegate& OnCompletedRequest = FLootLockerServerListContextsResponseDelegate());
 };

--- a/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
+++ b/LootLockerServerSDK/Source/LootLockerServerSDK/Public/ServerAPI/LootLockerServerAssetRequest.h
@@ -10,6 +10,36 @@
 #include "LootLockerServerAssetRequest.generated.h"
 
 //==================================================
+// Enums
+//==================================================
+
+/// @addtogroup Assets
+/// @{
+UENUM(BlueprintType)
+/** Fields by which an asset list can be ordered. */
+enum class ELootLockerServerOrderAssetListBy : uint8
+{
+    None = 0,
+    Id = 1,
+    Name = 2,
+    Created_at = 3,
+    Updated_at = 4
+};
+/// @}
+
+/// @addtogroup Assets
+/// @{
+UENUM(BlueprintType)
+/** Sort direction when ordering an asset list. */
+enum class ELootLockerServerOrderAssetListDirection : uint8
+{
+    None = 0,
+    Asc = 1,
+    Desc = 2
+};
+/// @}
+
+//==================================================
 // Data Type Definitions
 //==================================================
 
@@ -824,6 +854,6 @@ class LOOTLOCKERSERVERSDK_API ULootLockerServerAssetRequest : public UObject
     static FString UpdateKeyValuePairsOnAssetInstance(int PlayerID, int AssetInstanceID, TArray<FLootLockerServerAssetStorageKeyValueSet> KeyValuePairs, const FLootLockerServerAssetInstanceKeyValuePairsListResponseDelegate& OnCompletedRequest);
     static FString UpdateKeyValuePairOnAssetInstanceById(int PlayerID, int AssetInstanceID, int KeyValuePairID, const FString Key, FString Value, const FLootLockerServerAssetInstanceKeyValuePairItemResponseDelegate& OnCompletedRequest);
     static FString DeleteKeyValuePairFromAssetInstanceById(int PlayerID, int AssetInstanceID, int KeyValuePairID, const FLootLockerServerAssetInstanceKeyValuePairsListResponseDelegate& OnCompletedRequest);
-    static FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage = 0, int Page = 0, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest = FLootLockerServerListAssetsResponseDelegate());
+    static FString ListAssets(const FLootLockerServerListAssetsRequest& Request, int PerPage = 0, int Page = 0, ELootLockerServerOrderAssetListBy OrderBy = ELootLockerServerOrderAssetListBy::None, ELootLockerServerOrderAssetListDirection OrderDirection = ELootLockerServerOrderAssetListDirection::None, const FLootLockerServerListAssetsResponseDelegate& OnCompletedRequest = FLootLockerServerListAssetsResponseDelegate());
     static FString ListContexts(int PerPage = 0, int Page = 0, const FLootLockerServerListContextsResponseDelegate& OnCompletedRequest = FLootLockerServerListContextsResponseDelegate());
 };


### PR DESCRIPTION
Adds order_by and order_direction query parameters to the server SDK's ListAssets method, matching the existing game SDK and backend support.

### Changes
- **New enums**: ELootLockerServerOrderAssetListBy (None, Id, Name, Created_at, Updated_at)
- **New enums**: ELootLockerServerOrderAssetListDirection (None, Asc, Desc)
- **Updated ListAssets** across all 5 layers: request handler, C++ facade, BP facade
- **Backward compatible**: new params default to None, preserving existing behavior
- **Compile check**: ✅ all three targets pass

Closes lootlocker/index#1180